### PR TITLE
Make compatible with MW 1.25+

### DIFF
--- a/WatchAnalytics.php
+++ b/WatchAnalytics.php
@@ -207,6 +207,12 @@ $GLOBALS['wgResourceModules'] += array(
 
 );
 
+// array of form array( 'table' => ..., 'column' => ..., 'join_column' => ... )
+// where the table is the database table to get the page hit counter info,
+// the column is the column within that table with the hit counter, and
+// join_column is an integer that joins this table with page.page_id
+$GLOBALS['egWatchAnalyticsPageCounter'] = false;
+
 $GLOBALS['egPendingReviewsEmphasizeDays'] = 7;
 $GLOBALS['egPendingReviewsRedPagesThreshold'] = 2; // 0 or 1 reviewers BESIDES the person who made the change
 $GLOBALS['egPendingReviewsOrangePagesThreshold'] = 4; // 2 or 3 reviewers BESIDES the person who made the change

--- a/includes/PageWatchesQuery.php
+++ b/includes/PageWatchesQuery.php
@@ -136,13 +136,22 @@ class PageWatchesQuery extends WatchesQuery {
 		$queryInfo = $this->getQueryInfo( 'p.page_id IN (' . $pagesList . ')' );
 		$queryInfo['options'][ 'ORDER BY' ] = 'num_watches ASC';
 
+		$cols = array(
+				'p.page_id AS page_id',
+				$this->sqlNumWatches, // 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches'
+		);
+
+		global $wgVersion;
+		// no page counter in MW 1.25+
+		$hasPageCounter = version_compare( $wgVersion, '1.25', '<' );
+		if ( $hasPageCounter ) {
+			$cols[] = 'p.page_counter AS num_views';
+		}
+
+
 		$pageWatchStats = $dbr->select(
 			$queryInfo['tables'],
-			array(
-				'p.page_id AS page_id',
-				'p.page_counter AS num_views',
-				$this->sqlNumWatches, // 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches'
-			),
+			$cols,
 			$queryInfo['conds'],
 			__METHOD__,
 			$queryInfo['options'],
@@ -151,6 +160,9 @@ class PageWatchesQuery extends WatchesQuery {
 
 		$return = array();
 		while ( $row = $pageWatchStats->fetchObject() ) {
+			if ( ! isset( $row->num_views ) ) {
+				$row->num_views = 1;
+			}
 			$return[] = $row;
 		}
 

--- a/includes/PageWatchesQuery.php
+++ b/includes/PageWatchesQuery.php
@@ -137,17 +137,21 @@ class PageWatchesQuery extends WatchesQuery {
 		$queryInfo['options'][ 'ORDER BY' ] = 'num_watches ASC';
 
 		$cols = array(
-				'p.page_id AS page_id',
-				$this->sqlNumWatches, // 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches'
+			'p.page_id AS page_id',
+			$this->sqlNumWatches, // 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches'
 		);
 
-		global $wgVersion;
-		// no page counter in MW 1.25+
-		$hasPageCounter = version_compare( $wgVersion, '1.25', '<' );
-		if ( $hasPageCounter ) {
-			$cols[] = 'p.page_counter AS num_views';
-		}
+		global $egWatchAnalyticsPageCounter;
+		if ( $egWatchAnalyticsPageCounter ) {
+			$queryInfo['tables']['counter'] = $egWatchAnalyticsPageCounter['table'];
+			$countCol = $egWatchAnalyticsPageCounter['column'];
+			$countPageIdJoinCol = $egWatchAnalyticsPageCounter['join_column'];
 
+			$cols[] = "counter.$countCol AS num_views";
+			$queryInfo['join_conds']['counter'] = array(
+				'LEFT JOIN' , "p.page_id = counter.$countPageIdJoinCol"
+			);
+		}
 
 		$pageWatchStats = $dbr->select(
 			$queryInfo['tables'],


### PR DESCRIPTION
MediaWiki versions 1.24 and earlier had a page_counter column in the page table. This column was being minorly used by the Watch Suggest feature. Upgrading to MW 1.25 made the Pending Reviews page not work because of the absence of this column.

This pull request creates a configuration variable $egWatchAnalyticsPageCounter, which can be configured in LocalSettings.php as follows for versions less than or equal to 1.24:

```php
$egWatchAnalyticsPageCounter = array(
	'table' => 'page',
	'column' => 'page_counter',
	'join_column' => 'page_id'
);
```

For versions of MW 1.25+, this config variable should be left at its default value (false), disabling the use of a page views counter. If a page view counter is desired it must be provided by another extension, and have a database table with at least two columns: a page ID column corresponding to page.page_id and a column for counting the number of hits. Note that at this time [Extension:Wiretap](https://github.com/enterprisemediawiki/Wiretap) does not provide this feature, but in the near future it will, and will likely provide several counter columns for different lengths of time (hits in the last week, month, all time, etc)