### PR TITLE
Fix issue where addModuleStyles doesn't load CSS if JS also in module (T92459)

### DIFF
--- a/Hooks.php
+++ b/Hooks.php
@@ -100,6 +100,7 @@ class WatchAnalyticsHooks {
 			$pageScore = new PageScore( $title );
 			$out->addScript( $pageScore->getPageScoreTemplate() );
 			$out->addModules( 'ext.watchanalytics.pagescores.scripts' );
+			$out->addModuleStyles( 'ext.watchanalytics.pagescores.styles' );
 		}
 
 

--- a/Hooks.php
+++ b/Hooks.php
@@ -99,7 +99,7 @@ class WatchAnalyticsHooks {
 
 			$pageScore = new PageScore( $title );
 			$out->addScript( $pageScore->getPageScoreTemplate() );
-			$out->addModules( array( 'ext.watchanalytics.pagescores' ) );
+			$out->addModules( 'ext.watchanalytics.pagescores.scripts' );
 		}
 
 
@@ -112,7 +112,10 @@ class WatchAnalyticsHooks {
 
 		// 	// display "unreview" button
 		// 	$out->addScript( $reviewHandler->getTemplate() );
-		// 	$out->addModules( array( 'ext.watchanalytics.reviewhandler' ) );
+		//  $wgOut->addModules( [
+		//    'ext.watchanalytics.reviewhandler.scripts',
+		//    'ext.watchanalytics.reviewhandler.styles'
+		//  ] );
 
 		// 	// record change in user/page stats
 		// 	WatchStateRecorder::recordReview( $user, $title );
@@ -258,7 +261,10 @@ class WatchAnalyticsHooks {
 
 			// display "unreview" button
 			$wgOut->addScript( $reviewHandler->getTemplate() );
-			$wgOut->addModules( array( 'ext.watchanalytics.reviewhandler' ) );
+			$wgOut->addModules( [
+				'ext.watchanalytics.reviewhandler.scripts',
+				'ext.watchanalytics.reviewhandler.styles'
+			] );
 
 			// record change in user/page stats
 			WatchStateRecorder::recordReview( $user, $title );

--- a/extension.json
+++ b/extension.json
@@ -61,9 +61,8 @@
 			"position": "bottom",
 			"styles": "base/ext.watchanalytics.base.css"
 		},
-		"ext.watchanalytics.forcegraph": {
+		"ext.watchanalytics.forcegraph.scripts": {
 			"position": "bottom",
-			"styles": "forcegraph/ext.watchanalytics.forcegraph.css",
 			"scripts": [
 				"forcegraph/ext.watchanalytics.circlesort.js",
 				"forcegraph/ext.watchanalytics.forcegraph.js"
@@ -77,17 +76,24 @@
 				"d3.js"
 			]
 		},
+		"ext.watchanalytics.forcegraph.styles": {
+			"position": "bottom",
+			"styles": "forcegraph/ext.watchanalytics.forcegraph.css"
+		},
 		"ext.watchanalytics.specials": {
 			"position": "bottom",
 			"styles": "specials/ext.watchanalytics.specials.css"
 		},
-		"ext.watchanalytics.pendingreviews": {
+		"ext.watchanalytics.pendingreviews.scripts": {
 			"position": "bottom",
-			"styles": "pendingreviews/ext.watchanalytics.pendingreviews.css",
 			"scripts": "pendingreviews/ext.watchanalytics.pendingreviews.js",
 			"dependencies": [
 				"mediawiki.Title"
 			]
+		},
+		"ext.watchanalytics.pendingreviews.styles": {
+			"position": "bottom",
+			"styles": "pendingreviews/ext.watchanalytics.pendingreviews.css"
 		},
 		"underscore.js": {
 			"position": "bottom",
@@ -110,19 +116,21 @@
 				"jquery.effects.shake"
 			]
 		},
-		"ext.watchanalytics.pagescores": {
+		"ext.watchanalytics.pagescores.scripts": {
 			"position": "bottom",
-			"styles": "pagescores/pagescores.css",
-			"scripts": [
-				"pagescores/pagescores.js"
-			]
+			"scripts": "pagescores/pagescores.js"
 		},
-		"ext.watchanalytics.reviewhandler": {
+		"ext.watchanalytics.pagescores.styles": {
 			"position": "bottom",
-			"styles": "reviewhandler/reviewhandler.css",
-			"scripts": [
-				"reviewhandler/reviewhandler.js"
-			]
+			"styles": "pagescores/pagescores.css"
+		},
+		"ext.watchanalytics.reviewhandler.scripts": {
+			"position": "bottom",
+			"styles": "reviewhandler/reviewhandler.css"
+		},
+		"ext.watchanalytics.reviewhandler.styles": {
+			"position": "bottom",
+			"scripts": "reviewhandler/reviewhandler.js"
 		},
 		"ext.watchanalytics.charts": {
 			"position": "bottom",

--- a/extension.json
+++ b/extension.json
@@ -126,11 +126,11 @@
 		},
 		"ext.watchanalytics.reviewhandler.scripts": {
 			"position": "bottom",
-			"styles": "reviewhandler/reviewhandler.css"
+			"scripts": "reviewhandler/reviewhandler.js"
 		},
 		"ext.watchanalytics.reviewhandler.styles": {
 			"position": "bottom",
-			"scripts": "reviewhandler/reviewhandler.js"
+			"styles": "reviewhandler/reviewhandler.css"
 		},
 		"ext.watchanalytics.charts": {
 			"position": "bottom",

--- a/specials/SpecialPageStatistics.php
+++ b/specials/SpecialPageStatistics.php
@@ -48,7 +48,7 @@ class SpecialPageStatistics extends SpecialPage {
 			if ( $unReviewTimestamp ) {
 				$rh = new ReviewHandler( $wgUser, $this->mTitle );
 				$rh->resetNotificationTimestamp( $unReviewTimestamp );
-				$wgOut->addModuleStyles( array( 'ext.watchanalytics.reviewhandler' ) );
+				$wgOut->addModuleStyles( array( 'ext.watchanalytics.reviewhandler.styles' ) );
 				$wgOut->addHTML( $this->unReviewMessage() );
 			}
 
@@ -68,7 +68,7 @@ class SpecialPageStatistics extends SpecialPage {
 
 	public function getPageHeader() {
 		global $wgOut;
-		$wgOut->addModuleStyles( array( 'ext.watchanalytics.pagescores' ) );
+		$wgOut->addModuleStyles( array( 'ext.watchanalytics.pagescores.styles' ) );
 
 
 		$pageScore = new PageScore( $this->mTitle );
@@ -118,9 +118,9 @@ class SpecialPageStatistics extends SpecialPage {
 		$dbr = wfGetDB( DB_SLAVE );
 		$html = '';
 		// Load the module for the D3.js force directed graph
-		// $wgOut->addModules( array( 'ext.watchanalytics.forcegraph' ) );
+		// $wgOut->addModules( 'ext.watchanalytics.forcegraph.scripts' );
 		// Load the styles for the D3.js force directed graph
-		// $wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph' );
+		// $wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph.styles' );
 
 
 		// SELECT

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -113,10 +113,10 @@ class SpecialPendingReviews extends SpecialPage {
 		// Note: doing $out->addModules( ... ) instead of the two separate
 		// functions causes the CSS to load later, which makes the page styles
 		// apply late. This looks bad.
-		$wgOut->addModuleStyles( array(
+		$wgOut->addModuleStyles( [
 			'ext.watchanalytics.specials',
-			// 'ext.watchanalytics.pendingreviews.styles',
-		) );
+			'ext.watchanalytics.pendingreviews.styles',
+		] );
 
 		// how many reviews to display
 		$this->setReviewLimit();

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -107,7 +107,7 @@ class SpecialPendingReviews extends SpecialPage {
 		$this->setPendingReviewsUser();
 
 		// add pending reviews JS (and CSS, but need to explicitly call it below)
-		$wgOut->addModules( 'ext.watchanalytics.pendingreviews' );
+		$wgOut->addModules( 'ext.watchanalytics.pendingreviews.scripts' );
 
 		// load styles for watch analytics special pages
 		// Note: doing $out->addModules( ... ) instead of the two separate
@@ -115,7 +115,7 @@ class SpecialPendingReviews extends SpecialPage {
 		// apply late. This looks bad.
 		$wgOut->addModuleStyles( array(
 			'ext.watchanalytics.specials',
-			'ext.watchanalytics.pendingreviews',
+			// 'ext.watchanalytics.pendingreviews.styles',
 		) );
 
 		// how many reviews to display

--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -198,9 +198,9 @@ class SpecialWatchAnalytics extends SpecialPage {
 		$dbr = wfGetDB( DB_SLAVE );
 
 		// Load the module for the D3.js force directed graph
-		$wgOut->addModules( array( 'ext.watchanalytics.forcegraph' ) );
+		$wgOut->addModules( 'ext.watchanalytics.forcegraph.scripts' );
 		// Load the styles for the D3.js force directed graph
-		$wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph' );
+		$wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph.styles' );
 
 		// SELECT
 		// 	watchlist.wl_title AS title,


### PR DESCRIPTION
Fix for https://phabricator.wikimedia.org/T92459

If a resource loader module has both styles and scripts, it cannot be loaded with `addModuleStyles` anymore. 