### PR TITLE
Fix for SQL queries missing table prefixes. 

### DIFF
--- a/includes/PageWatchesQuery.php
+++ b/includes/PageWatchesQuery.php
@@ -89,7 +89,7 @@ class PageWatchesQuery extends WatchesQuery {
 		}
 
 		// add user watch scores join
-		$this->tables['user_watch_scores'] = '(
+		$this->tables['user_watch_scores'] = "(
 			SELECT
 				w2.wl_user AS user_name,
 				(
@@ -110,10 +110,10 @@ class PageWatchesQuery extends WatchesQuery {
 					1), 3)
 				) AS engagement_score
 
-			FROM watchlist AS w2
+			FROM {$GLOBALS['wgDBprefix']}watchlist AS w2
 			GROUP BY w2.wl_user
 
-		)';
+		)";
 		$this->join_conds['user_watch_scores'] = array(
 			'LEFT JOIN', 'user_watch_scores.user_name = w.wl_user'
 		);

--- a/includes/PendingReview.php
+++ b/includes/PendingReview.php
@@ -202,12 +202,12 @@ class PendingReview {
 			'w.wl_namespace AS namespace',
 			'w.wl_title AS title',
 			'w.wl_notificationtimestamp AS notificationtimestamp',
-			'(SELECT COUNT(*) FROM watchlist AS subwatch
+			"(SELECT COUNT(*) FROM {$GLOBALS['wgDBprefix']}watchlist AS subwatch
 			  WHERE
 				subwatch.wl_namespace = w.wl_namespace
 				AND subwatch.wl_title = w.wl_title
 				AND subwatch.wl_notificationtimestamp IS NULL
-			) AS num_reviewed',
+			) AS num_reviewed",
 		);
 
 		$conds = 'w.wl_user=' . $user->getId() . ' AND w.wl_notificationtimestamp IS NOT NULL';

--- a/includes/WatchAnalyticsParserFunctions.php
+++ b/includes/WatchAnalyticsParserFunctions.php
@@ -96,8 +96,8 @@ class WatchAnalyticsParserFunctions {
 					MAX(TIMESTAMPDIFF(MINUTE, w.wl_notificationtimestamp, UTC_TIMESTAMP())) AS max_pending_minutes,
 					AVG(TIMESTAMPDIFF(MINUTE, w.wl_notificationtimestamp, UTC_TIMESTAMP())) AS avg_pending_minutes,
 					(SELECT group_concat(cl_to SEPARATOR ';') as subq_categories FROM categorylinks WHERE cl_from = p.page_id) AS categories
-				FROM `watchlist` `w`
-				RIGHT JOIN `page` `p` ON ((p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title))
+				FROM `{$GLOBALS['wgDBprefix']}watchlist` `w`
+				RIGHT JOIN `{$GLOBALS['wgDBprefix']}page` `p` ON ((p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title))
 				WHERE
 					p.page_namespace = 0
 					AND p.page_is_redirect = 0
@@ -173,17 +173,17 @@ class WatchAnalyticsParserFunctions {
 					redir_page.page_id AS redir_id,
 					(
 						SELECT COUNT(*)
-						FROM watchlist AS watch
+						FROM {$GLOBALS['wgDBprefix']}watchlist AS watch
 						WHERE
 							watch.wl_namespace = p.page_namespace
 							AND watch.wl_title = p.page_title
 					) AS watches
-				FROM wiretap AS w
-				INNER JOIN page AS p ON
+				FROM {$GLOBALS['wgDBprefix']}wiretap AS w
+				INNER JOIN {$GLOBALS['wgDBprefix']}wage AS p ON
 					p.page_id = w.page_id
-				LEFT JOIN redirect AS red ON
+				LEFT JOIN {$GLOBALS['wgDBprefix']}redirect AS red ON
 					red.rd_from = p.page_id
-				LEFT JOIN page AS redir_page ON
+				LEFT JOIN {$GLOBALS['wgDBprefix']}page AS redir_page ON
 					red.rd_namespace = redir_page.page_namespace
 					AND red.rd_title = redir_page.page_title
 				WHERE
@@ -204,11 +204,11 @@ class WatchAnalyticsParserFunctions {
 						SUM( IF(w.wl_user = $wgUserId, 1, 0) ) AS wg_user_watches,
 						p.page_counter / SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS view_watch_ratio
 					FROM
-						watchlist AS w
-					LEFT JOIN page AS p ON
+						{$GLOBALS['wgDBprefix']}watchlist AS w
+					LEFT JOIN {$GLOBALS['wgDBprefix']}page AS p ON
 						w.wl_title = p.page_title
 						AND w.wl_namespace = p.page_namespace
-					LEFT JOIN revision AS r ON
+					LEFT JOIN {$GLOBALS['wgDBprefix']}revision AS r ON
 						r.rev_id = p.page_latest
 					WHERE
 						p.page_namespace = $namespace

--- a/maintenance/forgivePendingReviews.php
+++ b/maintenance/forgivePendingReviews.php
@@ -112,11 +112,11 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 		$reviewedBy = $this->getOption( 'reviewedby', $this->reviewedBy );
 
 		$query =
-			"UPDATE watchlist AS w
-			LEFT JOIN page AS p ON
+			"UPDATE {$GLOBALS['wgDBprefix']}watchlist AS w
+			LEFT JOIN {$GLOBALS['wgDBprefix']}page AS p ON
 				w.wl_title = p.page_title
 				AND w.wl_namespace = p.page_namespace
-			LEFT JOIN user AS u ON
+			LEFT JOIN {$GLOBALS['wgDBprefix']}user AS u ON
 				u.user_id = w.wl_user
 			SET wl_notificationtimestamp = NULL
 			WHERE
@@ -125,7 +125,7 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 				$usernames
 				AND (
 					SELECT COUNT(*)
-					FROM (SELECT * FROM watchlist) AS w2
+					FROM (SELECT * FROM {$GLOBALS['wgDBprefix']}watchlist) AS w2
 					WHERE
 						w.wl_namespace = w2.wl_namespace
 						AND w.wl_title = w2.wl_title

--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -96,14 +96,14 @@ class SpecialWatchAnalytics extends SpecialPage {
 		// 	)
 		// );
 
-		$res = $dbr->query( '
+		$res = $dbr->query( "
 			SELECT
 				COUNT(*) AS num_watches,
-				SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending,
-				SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending
-			FROM watchlist
-			INNER JOIN page ON page.page_namespace = watchlist.wl_namespace AND page.page_title = watchlist.wl_title;
-		' );
+				SUM( IF({$GLOBALS['wgDBprefix']}watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending,
+				SUM( IF({$GLOBALS['wgDBprefix']}watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending
+			FROM {$GLOBALS['wgDBprefix']}watchlist
+			INNER JOIN {$GLOBALS['wgDBprefix']}page ON {$GLOBALS['wgDBprefix']}page.page_namespace = {$GLOBALS['wgDBprefix']}watchlist.wl_namespace AND {$GLOBALS['wgDBprefix']}page.page_title = {$GLOBALS['wgDBprefix']}watchlist.wl_title;
+		" );
 
 		$allWikiData = $dbr->fetchRow( $res );
 


### PR DESCRIPTION
Most of the SQL queries were missing DB prefixes in front of the tables.
I added GLOBALS['wgDBprefix'] to each table reference that I found.