### PR TITLE
removes deprecated Revision::selectFields

### DIFF
--- a/includes/PendingReview.php
+++ b/includes/PendingReview.php
@@ -99,7 +99,7 @@ class PendingReview {
 
 			$revResults = $dbr->select(
 				array( 'r' => 'revision' ),
-				Revision::selectFields(),
+				Revision::getQueryInfo()['fields'],
 				// array(
 				// 	'r.rev_id AS rev_id',
 				// 	'r.rev_comment AS rev_comment',


### PR DESCRIPTION
This fixes deprecated class warning I receive when working on 1.31 or later. I think this class doesn't exist before 1.31 so I'm not sure how we want to handle older support.

Ref: https://doc.wikimedia.org/mediawiki-core/master/php/classMediaWiki_1_1Revision_1_1RevisionStore.html#a892c273781fb32e235c0ad526d1a1999

When merged this will closeout issue #78 

