### PR TITLE
Add error_reporting=32767 (E_ALL) to PHP syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - "5.6"
 before_script:
   # ref: https://stackoverflow.com/questions/45213498/how-to-syntax-check-php-files-in-travis-ci
-  - '! find . -type f -name "*.php" -exec php -l {} \; 2>&1 >&- | grep "^"'
+  - '! find . -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
 script:
   - bash ./build/travis/run-tests.sh
 


### PR DESCRIPTION
The default setting for error reporting in `php.ini` is:

```
error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
```

In other words: report all errors except deprecation and strict warnings. For our CI we should report everything. This change sets `error_reporting=32767` in our Travis CI job (32767 is the value of E_ALL).