### PR TITLE
Use MediaWiki CodeSniffer for code style checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+composer.lock
+vendor/*

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -2,11 +2,34 @@
 <ruleset name="MediaWiki">
 	<file>.</file>
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+
+		<!-- These exclusions taken from Extension:Echo and should be re-assessed -->
 		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
 		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
+
+		<!-- Allow non-wg prefix (e.g. $egWatchAnalyticsPageCounter) -->
+		<exclude name="MediaWiki.NamingConventions.ValidGlobalName.allowedPrefix" />
+		<!-- Same as above, but for PHP 5.6 (using MW CodeSniffer 19.1.0) -->
+		<exclude name="MediaWiki.NamingConventions.ValidGlobalName.wgPrefix" />
+
+		<!-- All -->
+		<exclude name="MediaWiki.PHP70Features.ScalarTypeHintUsage.Found" />
+		<exclude name="MediaWiki.PHP70Features.ScalarTypeHintUsage.ReturnTypeFound" />
+
+		<!--
+			Consider fixing while( $var = something() ) due to this:
+			https://www.mediawiki.org/wiki/Manual:Coding_conventions/PHP#Assignment_expressions
+		-->
+		<exclude name="MediaWiki.ControlStructures.AssignmentInControlStructures.AssignmentInControlStructures" />
+
+		<!--
+			This exclusion required because we use the database query() function directly rather
+			than using select() or other more specific functions
+		-->
+		<exclude name="MediaWiki.Usage.DbrQueryUsage.DbrQueryFound" />
 	</rule>
 	<rule ref="Generic.Files.LineLength">
 		<properties>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="MediaWiki">
+	<file>.</file>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
+	</rule>
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="140" />
+		</properties>
+	</rule>
+	<arg name="encoding" value="UTF-8" />
+	<arg name="extensions" value="php,php5,inc" />
+	<arg name="colors" />
+</ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -15,7 +15,7 @@
 		<!-- Same as above, but for PHP 5.6 (using MW CodeSniffer 19.1.0) -->
 		<exclude name="MediaWiki.NamingConventions.ValidGlobalName.wgPrefix" />
 
-		<!-- All -->
+		<!-- Allow type-hinting for scalars (e.g. int $myInt, string $myString) -->
 		<exclude name="MediaWiki.PHP70Features.ScalarTypeHintUsage.Found" />
 		<exclude name="MediaWiki.PHP70Features.ScalarTypeHintUsage.ReturnTypeFound" />
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
 before_script:
   # ref: https://stackoverflow.com/questions/45213498/how-to-syntax-check-php-files-in-travis-ci
   - '! find . -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
+  - composer install
 script:
+  - composer test
   - bash ./build/travis/run-tests.sh
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=5.6.0"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "23.0.0"
+		"mediawiki/mediawiki-codesniffer": "19.1.0 || 23.0.0"
 	},
 	"scripts": {
 		"test": [

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,10 @@
 	},
 	"scripts": {
 		"test": [
-			"phpcs -p -s",
-			"minus-x check ."
+			"phpcs -p -s"
 		],
 		"fix": [
-			"phpcbf",
-			"minus-x fix ."
+			"phpcbf"
 		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,24 @@
 		}
 	],
 	"support": {
-		"issues": "https://github.com/jamesmontalvo3/WatchAnalytics/issues",
+		"issues": "https://github.com/enterprisemediawiki/WatchAnalytics/issues",
 		"wiki": "https://www.mediawiki.org/wiki/Extension:WatchAnalytics",
-		"source": "https://github.com/jamesmontalvo3/WatchAnalytics"
+		"source": "https://github.com/enterprisemediawiki/WatchAnalytics"
 	},
 	"require": {
-		"php": ">=5.3.0",
-		"composer/installers": "1.*,>=1.0.1"
+		"php": ">=5.6.0"
 	},
-	"autoload": {
-		"files" : [
-			"WatchAnalytics.php"
-		]
-	},
-	"config": {
-		"process-timeout": 0
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "23.0.0"
 	},
 	"scripts": {
-		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist"
+		"test": [
+			"phpcs -p -s",
+			"minus-x check ."
+		],
+		"fix": [
+			"phpcbf",
+			"minus-x fix ."
+		]
 	}
 }


### PR DESCRIPTION
Use PHP CodeSniffer [1] with MediaWiki's standards [2] to check style. At present this will fail, but follow-on pull request(s) will fix the style issues. Additionally this PR does some other `composer.json` cleanup, including *removing the ability to install WatchAnalytics with Composer*. Composer is now only used to install dev dependencies (code sniffer for now, other testing packages later).

[1] https://github.com/squizlabs/PHP_CodeSniffer
[2] https://packagist.org/packages/mediawiki/mediawiki-codesniffer