### PR TITLE
Use PHP CodeSniffer to auto-fix style issues

### DIFF
--- a/Hooks.php
+++ b/Hooks.php
@@ -5,15 +5,12 @@ class WatchAnalyticsHooks {
 	/**
 	 * Handler for PersonalUrls hook. Replace the "watchlist" item on the user
 	 * toolbar ('personal URLs') with a link to Special:PendingReviews.
-	 *
 	 * @see http://www.mediawiki.org/wiki/Manual:Hooks/PersonalUrls
 	 *
-	 * @param &$personal_urls Array of URLs to append to.
-	 * @param &$title Title of page being visited.
-	 *
-	 * @return bool true in all cases
+	 * @param array &$personal_urls Array of URLs to append to.
+	 * @return bool
 	 */
-	public static function onPersonalUrls( &$personal_urls /*, &$title ,$sk*/ ) {
+	public static function onPersonalUrls( array &$personal_urls ) {
 		global $wgUser, $wgOut;
 		$user = $wgUser;
 
@@ -204,7 +201,7 @@ class WatchAnalyticsHooks {
 	 *
 	 * @see FIXME (include link to hook documentation)
 	 *
-	 * @param Array $magicWordVariableIDs array of names of magic words
+	 * @param Array &$magicWordVariableIDs array of names of magic words
 	 *
 	 * @return bool
 	 */
@@ -219,8 +216,8 @@ class WatchAnalyticsHooks {
 	 *
 	 * @see FIXME (include link to hook documentation)
 	 *
-	 * @param Parser $parser reference to MediaWiki parser.
-	 * @param string $text FIXME html/wikitext? of output page before complete
+	 * @param Parser &$parser reference to MediaWiki parser.
+	 * @param string &$text FIXME html/wikitext? of output page before complete
 	 *
 	 * @return bool
 	 */
@@ -278,12 +275,12 @@ class WatchAnalyticsHooks {
 	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageContentSaveComplete
 	 *
-	 * @param WikiPage $article
+	 * @param WikiPage $wikipage
 	 *
 	 * @return bool
 	 */
-	public static function onPageContentSaveComplete( $article ) {
-		WatchStateRecorder::recordPageChange( $article );
+	public static function onPageContentSaveComplete( WikiPage $wikipage ) {
+		WatchStateRecorder::recordPageChange( $wikipage );
 		return true;
 	}
 

--- a/Hooks.php
+++ b/Hooks.php
@@ -13,12 +13,11 @@ class WatchAnalyticsHooks {
 	 *
 	 * @return bool true in all cases
 	 */
-	static public function onPersonalUrls ( &$personal_urls /*, &$title ,$sk*/ ) {
-
+	public static function onPersonalUrls( &$personal_urls /*, &$title ,$sk*/ ) {
 		global $wgUser, $wgOut;
 		$user = $wgUser;
 
-		if ( !$user->isAllowed('pendingreviewslink') ) {
+		if ( !$user->isAllowed( 'pendingreviewslink' ) ) {
 			return true;
 		}
 
@@ -32,9 +31,9 @@ class WatchAnalyticsHooks {
 		$maxPendingDays = $watchStats['max_pending_days'];
 
 		// Determine CSS class of Watchlist/PendingReviews link
-		$personal_urls['watchlist']['class'] = array( 'mw-watchanalytics-watchlist-badge' );
+		$personal_urls['watchlist']['class'] = [ 'mw-watchanalytics-watchlist-badge' ];
 		if ( $numPending != 0 ) {
-			$personal_urls['watchlist']['class'] = array( 'mw-watchanalytics-watchlist-pending' );
+			$personal_urls['watchlist']['class'] = [ 'mw-watchanalytics-watchlist-pending' ];
 		}
 
 		// Determine text of Watchlist/PendingReviews link
@@ -42,8 +41,7 @@ class WatchAnalyticsHooks {
 		if ( $maxPendingDays > $egPendingReviewsEmphasizeDays ) {
 			$personal_urls['watchlist']['class'][] = 'mw-watchanalytics-watchlist-pending-old';
 			$text = wfMessage( 'watchanalytics-personal-url-old' )->params( $numPending, $maxPendingDays )->text();
-		}
-		else {
+		} else {
 			// when $sk (third arg) available, replace wfMessage with $sk->msg()
 			$text = wfMessage( 'watchanalytics-personal-url' )->params( $numPending )->text();
 		}
@@ -70,10 +68,9 @@ class WatchAnalyticsHooks {
 	 *
 	 * @return bool true in all cases
 	 */
-	static public function onBeforePageDisplay ( $out /*, $skin*/ ) {
+	public static function onBeforePageDisplay( $out /*, $skin*/ ) {
 		$user = $out->getUser();
 		$title = $out->getTitle();
-
 
 		#
 		# 1) Is user's oldest pending review is old enough to require emphasis
@@ -86,14 +83,13 @@ class WatchAnalyticsHooks {
 
 		global $egPendingReviewsEmphasizeDays;
 		if ( $user->watchStats['max_pending_days'] > $egPendingReviewsEmphasizeDays ) {
-			$out->addModules( array( 'ext.watchanalytics.shakependingreviews' ) );
+			$out->addModules( [ 'ext.watchanalytics.shakependingreviews' ] );
 		}
-
 
 		#
 		# 2) Insert page scores
 		#
-		if ( in_array( $title->getNamespace() , $GLOBALS['egWatchAnalyticsPageScoreNamespaces'] )
+		if ( in_array( $title->getNamespace(), $GLOBALS['egWatchAnalyticsPageScoreNamespaces'] )
 			&& $user->isAllowed( 'viewpagescore' )
 			&& PageScore::pageScoreIsEnabled() ) {
 
@@ -103,7 +99,6 @@ class WatchAnalyticsHooks {
 			$out->addModuleStyles( 'ext.watchanalytics.pagescores.styles' );
 		}
 
-
 		// REMOVED FOR MW 1.27
 		// #
 		// # 3) If user has reviewed page on this page load show "unreview" option
@@ -111,15 +106,15 @@ class WatchAnalyticsHooks {
 		// $reviewHandler = ReviewHandler::pageHasBeenReviewed();
 		// if ( $reviewHandler ) {
 
-		// 	// display "unreview" button
-		// 	$out->addScript( $reviewHandler->getTemplate() );
-		//  $wgOut->addModules( [
-		//    'ext.watchanalytics.reviewhandler.scripts',
-		//    'ext.watchanalytics.reviewhandler.styles'
-		//  ] );
+		// // display "unreview" button
+		// $out->addScript( $reviewHandler->getTemplate() );
+		// $wgOut->addModules( [
+		// 'ext.watchanalytics.reviewhandler.scripts',
+		// 'ext.watchanalytics.reviewhandler.styles'
+		// ] );
 
-		// 	// record change in user/page stats
-		// 	WatchStateRecorder::recordReview( $user, $title );
+		// // record change in user/page stats
+		// WatchStateRecorder::recordReview( $user, $title );
 
 		// }
 
@@ -149,9 +144,8 @@ class WatchAnalyticsHooks {
 	 *
 	 * @return bool true in all cases
 	 */
-	static public function onTitleMoveComplete ( Title &$originalTitle, Title &$newTitle,
+	public static function onTitleMoveComplete( Title &$originalTitle, Title &$newTitle,
 			User &$user, $oldid, $newid, $reason = null ) {
-
 		#
 		# Record move in watch stats
 		#
@@ -172,19 +166,19 @@ class WatchAnalyticsHooks {
 
 		$dbw = wfGetDB( DB_MASTER );
 		$results = $dbw->select( 'watchlist',
-			array( 'wl_user', 'wl_notificationtimestamp' ),
-			array( 'wl_namespace' => $oldNS, 'wl_title' => $oldDBkey ),
+			[ 'wl_user', 'wl_notificationtimestamp' ],
+			[ 'wl_namespace' => $oldNS, 'wl_title' => $oldDBkey ],
 			__METHOD__
 		);
 		# Construct array to replace into the watchlist
-		$values = array();
+		$values = [];
 		foreach ( $results as $oldRow ) {
-			$values[] = array(
+			$values[] = [
 				'wl_user' => $oldRow->wl_user,
 				'wl_namespace' => $newNS,
 				'wl_title' => $newDBkey,
 				'wl_notificationtimestamp' => $oldRow->wl_notificationtimestamp,
-			);
+			];
 		}
 
 		if ( empty( $values ) ) {
@@ -197,7 +191,7 @@ class WatchAnalyticsHooks {
 		# some other DBMSes, mostly due to poor simulation by us
 		$dbw->replace(
 			'watchlist',
-			array( array( 'wl_user', 'wl_namespace', 'wl_title' ) ),
+			[ [ 'wl_user', 'wl_namespace', 'wl_title' ] ],
 			$values,
 			__METHOD__
 		);
@@ -208,13 +202,13 @@ class WatchAnalyticsHooks {
 	/**
 	 * Register magic-word variable ID to hide page score from select pages.
 	 *
- 	 * @see FIXME (include link to hook documentation)
+	 * @see FIXME (include link to hook documentation)
 	 *
 	 * @param Array $magicWordVariableIDs array of names of magic words
 	 *
 	 * @return bool
 	 */
-	static public function addMagicWordVariableIDs( &$magicWordVariableIDs ) {
+	public static function addMagicWordVariableIDs( &$magicWordVariableIDs ) {
 		$magicWordVariableIDs[] = 'MAG_NOPAGESCORE';
 		return true;
 	}
@@ -223,14 +217,14 @@ class WatchAnalyticsHooks {
 	 * Set values in the page_props table based on the presence of the
 	 * 'NOPAGESCORE' magic word in a page
 	 *
- 	 * @see FIXME (include link to hook documentation)
+	 * @see FIXME (include link to hook documentation)
 	 *
 	 * @param Parser $parser reference to MediaWiki parser.
 	 * @param string $text FIXME html/wikitext? of output page before complete
 	 *
 	 * @return bool
 	 */
-	static public function handleMagicWords( &$parser, &$text ) {
+	public static function handleMagicWords( &$parser, &$text ) {
 		$magicWord = MagicWord::get( 'MAG_NOPAGESCORE' );
 		if ( $magicWord->matchAndRemove( $text ) ) {
 			// $parser->mOutput->setProperty( 'approvedrevs', 'y' );
@@ -251,8 +245,7 @@ class WatchAnalyticsHooks {
 	 *
 	 * @return bool
 	 */
-	static public function onPageViewUpdates ( WikiPage $wikiPage, User $user ) {
-
+	public static function onPageViewUpdates( WikiPage $wikiPage, User $user ) {
 		$title = $wikiPage->getTitle();
 		$reviewHandler = ReviewHandler::setup( $user, $title );
 
@@ -287,9 +280,9 @@ class WatchAnalyticsHooks {
 	 *
 	 * @param WikiPage $article
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	static public function onPageContentSaveComplete ( $article ) {
+	public static function onPageContentSaveComplete( $article ) {
 		WatchStateRecorder::recordPageChange( $article );
 		return true;
 	}
@@ -297,9 +290,9 @@ class WatchAnalyticsHooks {
 	public static function onLanguageGetMagic( &$magicWords, $langCode ) {
 		switch ( $langCode ) {
 		default:
-			$magicWords['underwatched_categories']    = array( 0, 'underwatched_categories' );
-			$magicWords['watchers_needed'] = array( 0, 'watchers_needed' );
-			$magicWords['MAG_NOPAGESCORE']   = array( 0, '__NOPAGESCORE__' );
+			$magicWords['underwatched_categories']    = [ 0, 'underwatched_categories' ];
+			$magicWords['watchers_needed'] = [ 0, 'watchers_needed' ];
+			$magicWords['MAG_NOPAGESCORE']   = [ 0, '__NOPAGESCORE__' ];
 		}
 		return true;
 	}

--- a/WatchAnalytics.i18n.magic.php
+++ b/WatchAnalytics.i18n.magic.php
@@ -1,13 +1,13 @@
 <?php
 
-$magicWords['en'] = array(
-   'underwatched_categories' => array(
-   		0, // zero means case-insensitive, 1 means case sensitive
-   		'underwatched_categories'
-   	),
-   'watchers_needed' => array(
-   		0, // zero means case-insensitive, 1 means case sensitive
-   		'watchers_needed'
-   	),
-   'MAG_NOPAGESCORE' => array( 0, '__NOPAGESCORE__' ),
-);
+$magicWords['en'] = [
+   'underwatched_categories' => [
+		0, // zero means case-insensitive, 1 means case sensitive
+		'underwatched_categories'
+	],
+   'watchers_needed' => [
+		0, // zero means case-insensitive, 1 means case sensitive
+		'watchers_needed'
+	],
+   'MAG_NOPAGESCORE' => [ 0, '__NOPAGESCORE__' ],
+];

--- a/WatchAnalyticsUser.php
+++ b/WatchAnalyticsUser.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -38,10 +38,9 @@ class WatchAnalyticsUser {
 	protected $user;
 	protected $pendingWatches;
 
-	public function __construct ( User $user ) {
+	public function __construct( User $user ) {
 		$this->user = $user;
 	}
-
 
 	/*
 	SELECT watchlist.wl_title, user.user_name
@@ -60,33 +59,31 @@ class WatchAnalyticsUser {
 		// user.user_real_name AS real_name
 	// FROM watchlist
 	// LEFT JOIN user ON user.user_id = watchlist.wl_user
-	public function getPendingWatches () {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getPendingWatches() {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$res = $dbr->select(
-			array( 'w' => 'watchlist' ),
-			array(
+			[ 'w' => 'watchlist' ],
+			[
 				'w.wl_namespace AS namespace_id',
 				'w.wl_title AS title_text',
 				'w.wl_notificationtimestamp AS notification_timestamp',
-			),
+			],
 			'w.wl_notificationtimestamp IS NOT NULL AND w.wl_user=' . $this->user->getId(),
 			__METHOD__,
-			array(
+			[
 				// "DISTINCT",
 				// "GROUP BY" => "w.hit_year, w.hit_month, w.hit_day",
 				// "ORDER BY" => "w.hit_year DESC, w.hit_month DESC, w.hit_day DESC",
 				"LIMIT" => "100000",
-			),
+			],
 			null // array( 'u' => array( 'LEFT JOIN', 'u.user-id=w.wl_user' ) )
 		);
-		$this->pendingWatches = array();
+		$this->pendingWatches = [];
 		while ( $row = $dbr->fetchRow( $res ) ) {
 
 			// $title = Title::newFromText( $row['title_text'], $row['notification_timestamp'] );
 			$this->pendingWatches[] = $row;
-
 
 		}
 

--- a/WatchAnalyticsUser.php
+++ b/WatchAnalyticsUser.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchAnalyticsUser {
 
@@ -42,23 +9,6 @@ class WatchAnalyticsUser {
 		$this->user = $user;
 	}
 
-	/*
-	SELECT watchlist.wl_title, user.user_name
-	FROM watchlist
-	LEFT JOIN user ON
-		user.user_id = watchlist.wl_user
-	WHERE
-		wl_notificationtimestamp IS NOT NULL
-		AND user.user_name = 'Cmavridi';
-	*/
-	// SELECT
-		// watchlist.wl_title AS title,
-		// watchlist.wl_namespace AS namespace,
-		// watchlist.wl_notificationtimestamp AS notification,
-		// user.user_name AS user_name,
-		// user.user_real_name AS real_name
-	// FROM watchlist
-	// LEFT JOIN user ON user.user_id = watchlist.wl_user
 	public function getPendingWatches() {
 		$dbr = wfGetDB( DB_REPLICA );
 

--- a/includes/PageScore.php
+++ b/includes/PageScore.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -51,23 +51,22 @@ class PageScore {
 	 */
 	public $cssColorClasses;
 
-	public function __construct ( Title $title ) {
-
+	public function __construct( Title $title ) {
 		$this->mTitle = $title;
-		$this->cssColorClasses = array(
+		$this->cssColorClasses = [
 			'excellent',
 			// 'good',
 			'okay',
 			// 'warning',
 			'danger',
-		);
+		];
 	}
 
-	static public function noPageScore () {
+	public static function noPageScore() {
 		self::$displayPageScore = false;
 	}
 
-	static public function pageScoreIsEnabled () {
+	public static function pageScoreIsEnabled() {
 		return self::$displayPageScore;
 	}
 
@@ -76,60 +75,53 @@ class PageScore {
 	 *
 	 * @return string
 	 */
-	public function getWatchQuality () {
+	public function getWatchQuality() {
 		$pwq = new PageWatchesQuery();
 		return round( $pwq->getPageWatchQuality( $this->mTitle ), 1 );
 	}
 
-	public function getReviewStatus () {
+	public function getReviewStatus() {
 		return $this->getNumReviews();
 	}
 
-	public function getNumReviews () {
-
-		$dbr = wfGetDB( DB_SLAVE );
-
+	public function getNumReviews() {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$pageData = $dbr->selectRow(
 			'watchlist',
 			'COUNT(*) AS num_reviews',
-			array(
+			[
 				'wl_notificationtimestamp IS NULL',
 				'wl_namespace' => $this->mTitle->getNamespace(),
 				'wl_title' => $this->mTitle->getDBkey()
-			),
+			],
 			__METHOD__
 		);
 
 		return $pageData->num_reviews;
-
 	}
 
-	public function getScoreColor ( $score, $configVariable ) {
-
+	public function getScoreColor( $score, $configVariable ) {
 		$scoreArr = $GLOBALS[ $configVariable ];
 
 		$scoreArrCount = count( $scoreArr );
-		for ( $i = 0; $i < $scoreArrCount; $i++ ) { //  ) as $index => $upperBound
+		for ( $i = 0; $i < $scoreArrCount; $i++ ) { // ) as $index => $upperBound
 			if ( $score > $scoreArr[ $i ] ) {
 				return $this->cssColorClasses[ $i ];
 			}
 		}
 		return $this->cssColorClasses[ count( $scoreArr ) ];
-
 	}
 
-
-	public function getPageScoreTemplate () {
-
+	public function getPageScoreTemplate() {
 		// simple explanation of what PageScores are
 		$pageScoresTooltip = wfMessage( 'watch-analytics-page-score-tooltip' )->text();
 
 		// @FIXME: Replace with special page showing page stats
 		// $pageScoresHelpPageLink = Title::makeTitle( NS_HELP, "Page Scores" )->getInternalURL();
-		$pageScoresHelpPageLink = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( array(
+		$pageScoresHelpPageLink = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( [
 			'page' => $this->mTitle->getPrefixedText()
-		) );
+		] );
 
 		// when MW 1.25 is released (very soon) replace this with a mustache template
 		$template =
@@ -139,23 +131,19 @@ class PageScore {
 			. "</a>";
 
 		return "<script type='text/template' id='ext-watchanalytics-pagescores-template'>$template</script>";
-
 	}
 
-	public function getBadge ( $label, $score, $color, $showLabel = false ) {
-
+	public function getBadge( $label, $score, $color, $showLabel = false ) {
 		// @todo FIXME: make the javascript apply a class to handle this, so this can just apply a class
 		if ( $showLabel ) {
 			$leftStyle = " style='display:inherit; border-radius: 4px 0 0 4px;'";
 			$rightStyle = " style='border-radius: 0 4px 4px 0;'";
-		}
-		else {
+		} else {
 			$leftStyle = "";
 			$rightStyle = "";
 		}
 
-		return
-			"<div class='ext-watchanalytics-pagescores-$color'>
+		return "<div class='ext-watchanalytics-pagescores-$color'>
 				<div class='ext-watchanalytics-pagescores-left'$leftStyle>
 					$label
 				</div>
@@ -163,10 +151,9 @@ class PageScore {
 					$score
 				</div>
 			</div>";
-
 	}
 
-	public function getScrutinyBadge ( $showLabel = false ) {
+	public function getScrutinyBadge( $showLabel = false ) {
 		$scrutinyScore = $this->getWatchQuality();
 		$scrutinyLabel = wfMessage( 'watch-analytics-page-score-scrutiny-label' )->text();
 		$scrutinyColor = $this->getScoreColor( $scrutinyScore, 'egWatchAnalyticsWatchQualityColors' );
@@ -174,7 +161,7 @@ class PageScore {
 		return $this->getBadge( $scrutinyLabel, $scrutinyScore, $scrutinyColor, $showLabel );
 	}
 
-	public function getReviewsBadge ( $showLabel = false ) {
+	public function getReviewsBadge( $showLabel = false ) {
 		$reviewsScore = $this->getReviewStatus();
 		$reviewsLabel = wfMessage( 'watch-analytics-page-score-reviews-label' )->text();
 		$reviewsColor = $this->getScoreColor( $reviewsScore, 'egWatchAnalyticsReviewStatusColors' );

--- a/includes/PageScore.php
+++ b/includes/PageScore.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class PageScore {
 

--- a/includes/PageWatchesQuery.php
+++ b/includes/PageWatchesQuery.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -41,7 +41,7 @@ class PageWatchesQuery extends WatchesQuery {
 	public $sqlPercentPending = 'SUM( IF(w.wl_title IS NOT NULL AND w.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending';
 	public $sqlWatchQuality = 'SUM( user_watch_scores.engagement_score ) AS watch_quality';
 
-	protected $fieldNames = array(
+	protected $fieldNames = [
 		'page_ns_and_title'       => 'watchanalytics-special-header-page-title',
 		'num_watches'             => 'watchanalytics-special-header-watches',
 		'num_reviewed'            => 'watchanalytics-special-header-reviewed-watches',
@@ -49,11 +49,10 @@ class PageWatchesQuery extends WatchesQuery {
 		'max_pending_minutes'     => 'watchanalytics-special-header-pending-maxtime',
 		'avg_pending_minutes'     => 'watchanalytics-special-header-pending-averagetime',
 		'watch_quality'           => 'watchanalytics-special-header-watch-quality',
-	);
+	];
 
 	public function getQueryInfo( $conds = null ) {
-
-		$this->fields = array(
+		$this->fields = [
 			$this->sqlNsAndTitle,
 			$this->sqlNumWatches,
 			$this->sqlNumReviewed,
@@ -61,27 +60,27 @@ class PageWatchesQuery extends WatchesQuery {
 			$this->sqlMaxPendingMins,
 			$this->sqlAvgPendingMins,
 			$this->sqlWatchQuality,
-		);
+		];
 
-		$this->conds = $conds ? $conds : array( 'p.page_namespace IS NOT NULL' );
+		$this->conds = $conds ? $conds : [ 'p.page_namespace IS NOT NULL' ];
 
-		$this->tables = array( 'w' => 'watchlist' );
+		$this->tables = [ 'w' => 'watchlist' ];
 
-		$this->join_conds = array();
+		$this->join_conds = [];
 
 		// optionally join the 'user_groups' table to filter by user group
 		if ( $this->userGroupFilter ) {
 			$this->tables['ug'] = 'user_groups';
-			$this->join_conds['ug'] = array(
+			$this->join_conds['ug'] = [
 				'RIGHT JOIN', "w.wl_user = ug.ug_user AND ug.ug_group = \"{$this->userGroupFilter}\""
-			);
+			];
 		}
 
 		// JOIN 'page' table
 		$this->tables['p'] = 'page';
-		$this->join_conds['p'] = array(
+		$this->join_conds['p'] = [
 			'RIGHT JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
-		);
+		];
 
 		// optionally join the 'categorylinks' table to filter by page category
 		if ( $this->categoryFilter ) {
@@ -114,32 +113,30 @@ class PageWatchesQuery extends WatchesQuery {
 			GROUP BY w2.wl_user
 
 		)';
-		$this->join_conds['user_watch_scores'] = array(
+		$this->join_conds['user_watch_scores'] = [
 			'LEFT JOIN', 'user_watch_scores.user_name = w.wl_user'
-		);
+		];
 
-		$this->options = array(
+		$this->options = [
 			// 'GROUP BY' => 'w.wl_title, w.wl_namespace'
 			'GROUP BY' => 'p.page_title, p.page_namespace',
-		);
+		];
 
 		return parent::getQueryInfo();
-
 	}
 
-	public function getPageWatchesAndViews ( $pages ) {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getPageWatchesAndViews( $pages ) {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$pagesList = $dbr->makeList( $pages );
 
 		$queryInfo = $this->getQueryInfo( 'p.page_id IN (' . $pagesList . ')' );
 		$queryInfo['options'][ 'ORDER BY' ] = 'num_watches ASC';
 
-		$cols = array(
+		$cols = [
 			'p.page_id AS page_id',
 			$this->sqlNumWatches, // 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches'
-		);
+		];
 
 		global $egWatchAnalyticsPageCounter;
 		if ( $egWatchAnalyticsPageCounter ) {
@@ -148,9 +145,9 @@ class PageWatchesQuery extends WatchesQuery {
 			$countPageIdJoinCol = $egWatchAnalyticsPageCounter['join_column'];
 
 			$cols[] = "counter.$countCol AS num_views";
-			$queryInfo['join_conds']['counter'] = array(
+			$queryInfo['join_conds']['counter'] = [
 				'LEFT JOIN' , "p.page_id = counter.$countPageIdJoinCol"
-			);
+			];
 		}
 
 		$pageWatchStats = $dbr->select(
@@ -162,7 +159,7 @@ class PageWatchesQuery extends WatchesQuery {
 			$queryInfo['join_conds']
 		);
 
-		$return = array();
+		$return = [];
 		while ( $row = $pageWatchStats->fetchObject() ) {
 			if ( ! isset( $row->num_views ) ) {
 				$row->num_views = 1;
@@ -171,48 +168,44 @@ class PageWatchesQuery extends WatchesQuery {
 		}
 
 		return $return;
-
 	}
 
-	public function getPageWatchers ( $titleKey, $ns = NS_MAIN ) {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getPageWatchers( $titleKey, $ns = NS_MAIN ) {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$pageWatchStats = $dbr->select(
-			array( 'w' => 'watchlist' ),
-			array( 'wl_user', 'wl_notificationtimestamp' ),
-			array(
+			[ 'w' => 'watchlist' ],
+			[ 'wl_user', 'wl_notificationtimestamp' ],
+			[
 				'w.wl_namespace' => $ns,
 				'w.wl_title' => $titleKey,
-			),
+			],
 			__METHOD__,
 			null, // no options
 			null // no join conds (no other tables)
 		);
 
-		$return = array();
+		$return = [];
 		while ( $row = $pageWatchStats->fetchObject() ) {
 			$return[] = $row;
 		}
 
 		return $return;
-
 	}
 
-	public function getPageWatchQuality ( Title $title ) {
+	public function getPageWatchQuality( Title $title ) {
+		$dbr = wfGetDB( DB_REPLICA );
 
-		$dbr = wfGetDB( DB_SLAVE );
-
-		$queryInfo = $this->getQueryInfo( array(
+		$queryInfo = $this->getQueryInfo( [
 			'p.page_namespace' => $title->getNamespace(),
 			'p.page_title' => $title->getDBkey(),
-		) );
+		] );
 
 		$pageData = $dbr->selectRow(
 			$queryInfo['tables'],
-			array(
+			[
 				$this->sqlWatchQuality
-			),
+			],
 			$queryInfo['conds'],
 			__METHOD__,
 			$queryInfo['options'],
@@ -222,11 +215,9 @@ class PageWatchesQuery extends WatchesQuery {
 		// $row = $pageData->fetchObject();
 		if ( $pageData ) {
 			return $pageData->watch_quality;
-		}
-		else {
+		} else {
 			return 0;
 		}
-
 	}
 
 }

--- a/includes/PageWatchesQuery.php
+++ b/includes/PageWatchesQuery.php
@@ -1,44 +1,12 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class PageWatchesQuery extends WatchesQuery {
 
 	public $sqlNsAndTitle = 'CONCAT(p.page_namespace, ":", p.page_title) AS page_ns_and_title';
 	public $sqlNumWatches = 'SUM( IF(w.wl_title IS NOT NULL, 1, 0) ) AS num_watches';
 	public $sqlNumReviewed = 'SUM( IF(w.wl_title IS NOT NULL AND w.wl_notificationtimestamp IS NULL, 1, 0) ) AS num_reviewed';
-	public $sqlPercentPending = 'SUM( IF(w.wl_title IS NOT NULL AND w.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending';
+	public $sqlPercentPending =
+		'SUM( IF(w.wl_title IS NOT NULL AND w.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending';
 	public $sqlWatchQuality = 'SUM( user_watch_scores.engagement_score ) AS watch_quality';
 
 	protected $fieldNames = [

--- a/includes/PendingReview.php
+++ b/includes/PendingReview.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -80,62 +80,59 @@ class PendingReview {
 	 */
 	public $log;
 
-	public function __construct ( $row ) {
-
+	public function __construct( $row ) {
 		$pageID = $row['page_id'];
 		$notificationTimestamp = $row['notificationtimestamp'];
 
 		if ( $pageID ) {
 			$title = Title::newFromID( $pageID );
-		}
-		else {
+		} else {
 			$title = false;
 		}
 
 		if ( $pageID && $title->exists() ) {
 
-			$dbr = wfGetDB( DB_SLAVE );
-
+			$dbr = wfGetDB( DB_REPLICA );
 
 			$revResults = $dbr->select(
-				array( 'r' => 'revision' ),
+				[ 'r' => 'revision' ],
 				Revision::getQueryInfo()['fields'],
 				// array(
-				// 	'r.rev_id AS rev_id',
-				// 	'r.rev_comment AS rev_comment',
-				// 	'r.rev_user AS rev_user_id',
-				// 	'r.rev_user_text AS rev_user_name',
-				// 	'r.rev_timestamp AS rev_timestamp',
-				// 	'r.rev_len AS rev_len',
+				// 'r.rev_id AS rev_id',
+				// 'r.rev_comment AS rev_comment',
+				// 'r.rev_user AS rev_user_id',
+				// 'r.rev_user_text AS rev_user_name',
+				// 'r.rev_timestamp AS rev_timestamp',
+				// 'r.rev_len AS rev_len',
 				// ),
 				"r.rev_page=$pageID AND r.rev_timestamp>=$notificationTimestamp",
 				__METHOD__,
-				array( 'ORDER BY' => 'rev_timestamp ASC' ),
+				[ 'ORDER BY' => 'rev_timestamp ASC' ],
 				null
 			);
-			$revsPending = array();
+			$revsPending = [];
 			while ( $rev = $revResults->fetchObject() ) {
 				$revsPending[] = $rev;
 			}
 
 			$logResults = $dbr->select(
-				array( 'l' => 'logging' ),
-				array( '*' ),
+				[ 'l' => 'logging' ],
+				[ '*' ],
 				// array(
-				// 	'l.log_id AS log_id',
-				// 	'l.log_type AS log_type',
-				// 	'l.log_action AS log_action',
-				// 	'l.log_timestamp AS log_timestamp',
-				// 	'l.log_user AS log_user_id',
-				// 	'l.log_user_text AS log_user_name',
+				// 'l.log_id AS log_id',
+				// 'l.log_type AS log_type',
+				// 'l.log_action AS log_action',
+				// 'l.log_timestamp AS log_timestamp',
+				// 'l.log_user AS log_user_id',
+				// 'l.log_user_text AS log_user_name',
 				// ),
 				"l.log_page=$pageID AND l.log_timestamp>=$notificationTimestamp
 					AND l.log_type NOT IN ('interwiki','newusers','patrol','rights','upload')",
 				__METHOD__,
-				array( 'ORDER BY' => 'log_timestamp ASC' ),
+				[ 'ORDER BY' => 'log_timestamp ASC' ],
 				null
 			);
-			$logPending = array();
+			$logPending = [];
 			while ( $log = $logResults->fetchObject() ) {
 				$logPending[] = $log;
 			}
@@ -144,15 +141,13 @@ class PendingReview {
 			$deletedTitle = false;
 			$deletionLog = false;
 
-		}
-		else {
+		} else {
 			$deletedNS = $row['namespace'];
 			$deletedTitle = $row['title'];
 			$deletionLog = $this->getDeletionLog( $deletedTitle, $deletedNS, $notificationTimestamp );
 			$logPending = false;
 			$revsPending = false;
 		}
-
 
 		$this->notificationTimestamp = $notificationTimestamp;
 		$this->title = $title;
@@ -162,7 +157,6 @@ class PendingReview {
 		$this->deletionLog = $deletionLog;
 		$this->log = $logPending;
 		$this->numReviewers = intval( $row['num_reviewed'] );
-
 	}
 
 	/*
@@ -188,15 +182,14 @@ class PendingReview {
 		ORDER BY w.wl_notificationtimestamp ASC;
 
 	*/
-	static public function getPendingReviewsList ( User $user, $limit, $offset ) {
-
-		$tables = array(
+	public static function getPendingReviewsList( User $user, $limit, $offset ) {
+		$tables = [
 			'w' => 'watchlist',
 			'p' => 'page',
 			'log' => 'logging',
-		);
+		];
 
-		$fields = array(
+		$fields = [
 			'p.page_id AS page_id',
 			'log.log_action AS log_action',
 			'w.wl_namespace AS namespace',
@@ -208,32 +201,31 @@ class PendingReview {
 				AND subwatch.wl_title = w.wl_title
 				AND subwatch.wl_notificationtimestamp IS NULL
 			) AS num_reviewed',
-		);
+		];
 
 		$conds = 'w.wl_user=' . $user->getId() . ' AND w.wl_notificationtimestamp IS NOT NULL';
 
-		$options = array(
+		$options = [
 			'ORDER BY' => 'num_reviewed ASC, w.wl_notificationtimestamp ASC',
 			'OFFSET' => $offset,
 			'LIMIT' => $limit,
-		);
+		];
 
-		$join_conds = array(
-			'p' => array(
+		$join_conds = [
+			'p' => [
 				'LEFT JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
-			),
-			'log' => array(
+			],
+			'log' => [
 				'LEFT JOIN',
 				'log.log_namespace = w.wl_namespace '
 				. ' AND log.log_title = w.wl_title'
 				. ' AND p.page_namespace IS NULL'
 				. ' AND p.page_title IS NULL'
 				. ' AND log.log_action IN ("delete","move")'
-			),
-		);
+			],
+		];
 
-
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$watchResult = $dbr->select(
 			$tables,
@@ -244,7 +236,7 @@ class PendingReview {
 			$join_conds
 		);
 
-		$pending = array();
+		$pending = [];
 
 		while ( $row = $dbr->fetchRow( $watchResult ) ) {
 
@@ -255,16 +247,15 @@ class PendingReview {
 		return $pending;
 	}
 
-	public function getDeletionLog ( $title, $ns, $notificationTimestamp ) {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getDeletionLog( $title, $ns, $notificationTimestamp ) {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$title = $dbr->addQuotes( $title );
 
 		// pages are deleted when (a) they are explicitly deleted or (b) they
 		// are moved without leaving a redirect behind.
 		$logResults = $dbr->select(
-			array( 'l' => 'logging' ),
+			[ 'l' => 'logging' ],
 			[
 				'log_id',
 				'log_type',
@@ -282,10 +273,10 @@ class PendingReview {
 			"l.log_title=$title AND l.log_namespace=$ns AND l.log_timestamp>=$notificationTimestamp
 				AND l.log_type IN ('delete','move')",
 			__METHOD__,
-			array( 'ORDER BY' => 'log_timestamp ASC' ),
+			[ 'ORDER BY' => 'log_timestamp ASC' ],
 			null
 		);
-		$logDeletes = array();
+		$logDeletes = [];
 		while ( $log = $logResults->fetchObject() ) {
 			$logDeletes[] = $log;
 		}
@@ -293,15 +284,13 @@ class PendingReview {
 		return $logDeletes;
 	}
 
-
 	/**
 	 * FIXME: This was copied from LogEntry::getParameters() because
 	 * I couldn't find a cleaner way to do it.
 	 *
 	 * var $logParams is the content of the column log_params in the logging table
 	 */
-	public static function getMoveTarget ( $logParams ) {
-
+	public static function getMoveTarget( $logParams ) {
 		wfSuppressWarnings();
 		$unserializedParams = unserialize( $logParams );
 		wfRestoreWarnings();
@@ -314,12 +303,11 @@ class PendingReview {
 			return $moveLogParams[ '4::target' ];
 
 		} else {
-			$moveLogParams = $logParams === '' ? array() : explode( "\n", $logParams );
+			$moveLogParams = $logParams === '' ? [] : explode( "\n", $logParams );
 			// $this->legacy = true;
 
 			return $moveLogParams[0];
 		}
-
 	}
 
 	/**
@@ -329,27 +317,24 @@ class PendingReview {
 	 * @param Title $title
 	 * @return string HTML for row
 	 */
-	public function clearByUserAndTitle ( $user, $title ) {
-
+	public function clearByUserAndTitle( $user, $title ) {
 		$watch = WatchedItem::fromUserTitle( $user, $title );
 		$watch->resetNotificationTimestamp();
 
 		// $wgOut->addHTML(
-		// 	wfMessage(
-		// 		'pendingreviews-clear-page-notification',
-		// 		$title->getFullText(),
-		// 		Xml::tags('a',
-		// 			array(
-		// 				'href' => $this->getTitle()->getLocalUrl(),
-		// 				'style' => 'font-weight:bold;',
-		// 			),
-		// 			$this->getTitle()
-		// 		)
-		// 	)->text()
+		// wfMessage(
+		// 'pendingreviews-clear-page-notification',
+		// $title->getFullText(),
+		// Xml::tags('a',
+		// array(
+		// 'href' => $this->getTitle()->getLocalUrl(),
+		// 'style' => 'font-weight:bold;',
+		// ),
+		// $this->getTitle()
+		// )
+		// )->text()
 		// );
 
 		return true;
-
-
 	}
 }

--- a/includes/PendingReview.php
+++ b/includes/PendingReview.php
@@ -228,7 +228,7 @@ class PendingReview {
 		return $logDeletes;
 	}
 
-	public static function getMoveTarget( mixed $logParams ) {
+	public static function getMoveTarget( $logParams ) {
 		// FIXME: This was copied from LogEntry::getParameters() because
 		// I couldn't find a cleaner way to do it.
 		// $logParams the content of the column log_params in the logging table

--- a/includes/PendingReview.php
+++ b/includes/PendingReview.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class PendingReview {
 
@@ -159,29 +126,6 @@ class PendingReview {
 		$this->numReviewers = intval( $row['num_reviewed'] );
 	}
 
-	/*
-		Make more like this:
-
-		SELECT
-			p.page_id AS id,
-			w.wl_namespace AS namespace,
-			w.wl_title AS title,
-			w.wl_notificationtimestamp AS notificationtimestamp
-		FROM `watchlist` `w`
-		LEFT JOIN `page` `p` ON
-			((p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title))
-		LEFT JOIN `logging` `log` ON
-			log.log_namespace = w.wl_namespace
-			AND log.log_title = w.wl_title
-			AND p.page_namespace IS NULL
-			AND p.page_title IS NULL
-			AND log.log_action = 'delete'
-		WHERE
-			w.wl_user=1
-			AND w.wl_notificationtimestamp IS NOT NULL
-		ORDER BY w.wl_notificationtimestamp ASC;
-
-	*/
 	public static function getPendingReviewsList( User $user, $limit, $offset ) {
 		$tables = [
 			'w' => 'watchlist',
@@ -284,13 +228,11 @@ class PendingReview {
 		return $logDeletes;
 	}
 
-	/**
-	 * FIXME: This was copied from LogEntry::getParameters() because
-	 * I couldn't find a cleaner way to do it.
-	 *
-	 * var $logParams is the content of the column log_params in the logging table
-	 */
-	public static function getMoveTarget( $logParams ) {
+	public static function getMoveTarget( mixed $logParams ) {
+		// FIXME: This was copied from LogEntry::getParameters() because
+		// I couldn't find a cleaner way to do it.
+		// $logParams the content of the column log_params in the logging table
+
 		wfSuppressWarnings();
 		$unserializedParams = unserialize( $logParams );
 		wfRestoreWarnings();

--- a/includes/ReviewHandler.php
+++ b/includes/ReviewHandler.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -63,12 +63,12 @@ class ReviewHandler {
 	 */
 	public $final = null;
 
-	public function __construct ( User $user, Title $title ) {
+	public function __construct( User $user, Title $title ) {
 		$this->user = $user;
 		$this->title = $title;
 	}
 
-	public static function setup ( User $user, Title $title ) {
+	public static function setup( User $user, Title $title ) {
 		if ( ! $title->isWatchable() ) {
 			self::$isReviewable = false;
 			return false;
@@ -83,39 +83,34 @@ class ReviewHandler {
 	 * and, if they're watching, whether they have reviewed the latest revision.
 	 *
 	 */
-	public function getReviewStatus () {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getReviewStatus() {
+		$dbr = wfGetDB( DB_REPLICA );
 
 		// FIXME: probably should use User->getNotificationTimestmap() or something
 		// but I'm on a plane and I don't know what is available to me without docs
 		$row = $dbr->selectRow(
 			'watchlist',
-			array( 'wl_notificationtimestamp' ),
-			array(
+			[ 'wl_notificationtimestamp' ],
+			[
 				'wl_user' => $this->user->getId(),
 				'wl_namespace' => $this->title->getNamespace(),
 				'wl_title' => $this->title->getDBkey(),
-			),
+			],
 			__METHOD__,
-			array()
+			[]
 		);
 
 		// user is not watching the page
 		if ( $row === false ) {
 			return -1;
-		}
-		else if ( $row->wl_notificationtimestamp === NULL ) {
+		} elseif ( $row->wl_notificationtimestamp === null ) {
 			return 0;
-		}
-		else {
+		} else {
 			return $row->wl_notificationtimestamp;
 		}
-
 	}
 
-	public static function pageIsBeingReviewed () {
-
+	public static function pageIsBeingReviewed() {
 		// never setup
 		if ( ! self::$isReviewable || self::$pageLoadHandler === null ) {
 			return false;
@@ -140,25 +135,23 @@ class ReviewHandler {
 		// or $newStatus is a timestamp greater than the original timestamp, meaning
 		// they have reviewed a more recent version of the page than they had originally
 		// if ( $newStatus < 1 || $newStatus > self::$pageLoadHandler->initial ) {
-		// 	self::$pageLoadHandler->final = $newStatus;
-		// 	return self::$pageLoadHandler;
+		// self::$pageLoadHandler->final = $newStatus;
+		// return self::$pageLoadHandler;
 		// }
 		// else {
-		// 	return false;
+		// return false;
 		// }
 
 		return true;
-
 	}
 
-	public function getTemplate () {
-
+	public function getTemplate() {
 		// $msg = wfMessage( 'watch-analytics-page-score-tooltip' )->text();
 
-		$unReviewLink = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( array(
+		$unReviewLink = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( [
 			'page' => $this->title->getPrefixedText(),
 			'unreview' => $this->initial
-		) );
+		] );
 
 		$linkText = wfMessage( 'watchanalytics-unreview-button' )->text();
 		$bannerText = wfMessage( 'watchanalytics-unreview-banner-text' )->parse();
@@ -171,27 +164,24 @@ class ReviewHandler {
 			</div>";
 
 		return "<script type='text/template' id='ext-watchanalytics-review-handler-template'>$template</script>";
-
 	}
 
-	public function resetNotificationTimestamp ( $ts ) {
-
+	public function resetNotificationTimestamp( $ts ) {
 		$dbw = wfGetDB( DB_MASTER );
 
 		return $dbw->update(
 			'watchlist',
-			array(
+			[
 				'wl_notificationtimestamp' => $ts,
-			),
-			array(
+			],
+			[
 				'wl_user' => $this->user->getId(),
 				'wl_namespace' => $this->title->getNamespace(),
 				'wl_title' => $this->title->getDBkey(),
-			),
+			],
 			__METHOD__,
 			null
 		);
-
 	}
 
 }

--- a/includes/ReviewHandler.php
+++ b/includes/ReviewHandler.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class ReviewHandler {
 
@@ -82,6 +49,7 @@ class ReviewHandler {
 	 * Get the "watch status" of a user for a page, e.g. whether they're watching
 	 * and, if they're watching, whether they have reviewed the latest revision.
 	 *
+	 * @return int
 	 */
 	public function getReviewStatus() {
 		$dbr = wfGetDB( DB_REPLICA );

--- a/includes/UserWatchesQuery.php
+++ b/includes/UserWatchesQuery.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -56,7 +56,7 @@ class UserWatchesQuery extends WatchesQuery {
 			),
 		1), 3) AS engagement_score';
 
-	protected $fieldNames = array(
+	protected $fieldNames = [
 		'user_name'               => 'watchanalytics-special-header-user',
 		'num_watches'             => 'watchanalytics-special-header-watches',
 		'num_pending'             => 'watchanalytics-special-header-pending-watches',
@@ -64,18 +64,17 @@ class UserWatchesQuery extends WatchesQuery {
 		'max_pending_minutes'     => 'watchanalytics-special-header-pending-maxtime',
 		'avg_pending_minutes'     => 'watchanalytics-special-header-pending-averagetime',
 		'engagement_score'        => 'watchanalytics-special-header-engagement-score',
-	);
+	];
 
 	public function getQueryInfo( $conds = null ) {
-
-		$this->tables = array(
+		$this->tables = [
 			'w' => 'watchlist',
 			'u' => 'user',
 			'p' => 'page',
 			'log' => 'logging',
-		);
+		];
 
-		$this->fields = array(
+		$this->fields = [
 			$this->sqlUserName,
 			$this->sqlNumWatches,
 			$this->sqlNumPending,
@@ -83,39 +82,38 @@ class UserWatchesQuery extends WatchesQuery {
 			$this->sqlMaxPendingMins,
 			$this->sqlAvgPendingMins,
 			$this->sqlEngagementScore,
-		);
+		];
 
-		$this->conds = $conds ? $conds : array();
+		$this->conds = $conds ? $conds : [];
 
-		$this->join_conds = array(
-			'u' => array(
+		$this->join_conds = [
+			'u' => [
 				'LEFT JOIN', 'u.user_id=w.wl_user'
-			),
-			'p' => array(
+			],
+			'p' => [
 				'LEFT JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
-			),
-			'log' => array(
+			],
+			'log' => [
 				'LEFT JOIN',
 				'log.log_namespace = w.wl_namespace '
 				. ' AND log.log_title = w.wl_title'
 				. ' AND p.page_namespace IS NULL'
 				. ' AND p.page_title IS NULL'
 				. ' AND log.log_action = "delete"'
-			),
-		);
+			],
+		];
 
 		// optionally join the 'user_groups' table to filter by user group
 		if ( $this->userGroupFilter ) {
 			$this->tables['ug'] = 'user_groups';
-			$this->join_conds['ug'] = array(
+			$this->join_conds['ug'] = [
 				'RIGHT JOIN', "w.wl_user = ug.ug_user AND ug.ug_group = \"{$this->userGroupFilter}\""
-			);
+			];
 
 			$noNullUsers = 'w.wl_user IS NOT NULL';
 			if ( is_array( $this->conds ) ) {
 				$this->conds[] = $noNullUsers;
-			}
-			else if ( is_string( $this->conds ) ) {
+			} elseif ( is_string( $this->conds ) ) {
 				$this->conds .= ' AND ' . $noNullUsers;
 			}
 		}
@@ -125,12 +123,11 @@ class UserWatchesQuery extends WatchesQuery {
 			$this->setCategoryFilterQueryInfo();
 		}
 
-		$this->options = array(
+		$this->options = [
 			'GROUP BY' => 'w.wl_user'
-		);
+		];
 
 		return parent::getQueryInfo();
-
 	}
 
 	/**
@@ -141,11 +138,10 @@ class UserWatchesQuery extends WatchesQuery {
 	 * @return array returns user watch info in an array with keys the same as
 	 * $this->fieldNames.
 	 */
-	public function getUserWatchStats ( User $user ) {
-
+	public function getUserWatchStats( User $user ) {
 		$qInfo = $this->getQueryInfo();
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$res = $dbr->select(
 			$qInfo['tables'],
@@ -161,7 +157,7 @@ class UserWatchesQuery extends WatchesQuery {
 		// if user doesn't have any pages in watchlist, then no data will be
 		// returned by this query. Create a "blank" row instead.
 		if ( $row === false ) {
-			$row = array();
+			$row = [];
 			foreach ( $this->fieldNames as $name => $msg ) {
 				$row[ $name ] = 0;
 			}
@@ -178,42 +174,41 @@ class UserWatchesQuery extends WatchesQuery {
 	 * @return Array returns user watch info in an array with user IDs as keys
 	 * and values being objects with params num_watches and num_pending.
 	 */
-	public function getMultiUserWatchStats ( Array $userIds ) {
-
+	public function getMultiUserWatchStats( array $userIds ) {
 		if ( ! count( $userIds ) ) {
-			return array();
+			return [];
 		}
 
-		$fields = array(
+		$fields = [
 			'w.wl_user',
 			$this->sqlNumWatches,
 			$this->sqlNumPending,
-		);
+		];
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		$res = $dbr->select(
-			array(
+			[
 				'w' => 'watchlist'
-			),
+			],
 			$fields,
-			array(
+			[
 				'w.wl_user' => $userIds
-			),
+			],
 			__METHOD__,
-			array(
+			[
 				'GROUP BY' => 'w.wl_user'
-			), // no options
+			], // no options
 			null // no joins
 		);
 
-		$return = array();
+		$return = [];
 		while ( $row = $res->fetchObject() ) {
-			$return[] = (object)array(
+			$return[] = (object)[
 				'wl_user' => $row->wl_user,
 				'num_watches' => $row->num_watches,
 				'num_pending' => $row->num_pending,
-			);
+			];
 		}
 
 		return $return;

--- a/includes/UserWatchesQuery.php
+++ b/includes/UserWatchesQuery.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class UserWatchesQuery extends WatchesQuery {
 

--- a/includes/WatchAnalyticsHtmlHelper.php
+++ b/includes/WatchAnalyticsHtmlHelper.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchAnalyticsHtmlHelper {
 

--- a/includes/WatchAnalyticsHtmlHelper.php
+++ b/includes/WatchAnalyticsHtmlHelper.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -35,8 +35,7 @@ EOT;
 
 class WatchAnalyticsHtmlHelper {
 
-	static public function formatListArray ( $list, $columns = 1, $listType = 'ol' ) {
-
+	public static function formatListArray( $list, $columns = 1, $listType = 'ol' ) {
 		// number of <li> elements
 		$numLI = count( $list );
 
@@ -45,8 +44,7 @@ class WatchAnalyticsHtmlHelper {
 
 		if ( $columns > 1 ) {
 			$perCol = ceil( $numLI / $columns );
-		}
-		else {
+		} else {
 			$perCol = $numLI + 1;
 		}
 
@@ -76,7 +74,6 @@ class WatchAnalyticsHtmlHelper {
 		$html .= "</td></tr></table>";
 
 		return $html;
-
 	}
 
 }

--- a/includes/WatchAnalyticsPageTablePager.php
+++ b/includes/WatchAnalyticsPageTablePager.php
@@ -2,7 +2,7 @@
 
 class WatchAnalyticsPageTablePager extends WatchAnalyticsTablePager {
 
-	protected $isSortable = array(
+	protected $isSortable = [
 		'page_ns_and_title' => true,
 		'num_watches' => true,
 		'num_reviewed' => true,
@@ -10,9 +10,9 @@ class WatchAnalyticsPageTablePager extends WatchAnalyticsTablePager {
 		'max_pending_minutes' => true,
 		'avg_pending_minutes' => true,
 		'watch_quality' => true,
-	);
+	];
 
-	public function __construct( $page, $conds, $filters = array() ) {
+	public function __construct( $page, $conds, $filters = [] ) {
 		global $wgRequest;
 
 		$this->watchQuery = new PageWatchesQuery();
@@ -26,7 +26,7 @@ class WatchAnalyticsPageTablePager extends WatchAnalyticsTablePager {
 			$this->mDefaultDirection = false;
 		}
 
-		$this->mExtraSortFields = array( 'num_watches', 'num_reviewed', 'page_ns_and_title' );
+		$this->mExtraSortFields = [ 'num_watches', 'num_reviewed', 'page_ns_and_title' ];
 	}
 
 	public function getQueryInfo() {
@@ -36,18 +36,16 @@ class WatchAnalyticsPageTablePager extends WatchAnalyticsTablePager {
 			&& $this->mQueryNamespace >= 0
 			&& isset( $namespaces[ $this->mQueryNamespace ] ) ) {
 
-			$conds = array(
+			$conds = [
 				'p.page_namespace = ' . $this->mQueryNamespace
-			);
-		}
-		else {
-			$conds = array();
+			];
+		} else {
+			$conds = [];
 		}
 		return $this->watchQuery->getQueryInfo( $conds );
 	}
 
-	public function formatValue ( $fieldName , $value ) {
-
+	public function formatValue( $fieldName, $value ) {
 		if ( $fieldName === 'page_ns_and_title' ) {
 			$pageInfo = explode( ':', $value, 2 );
 			$pageNsIndex = $pageInfo[0];
@@ -59,49 +57,42 @@ class WatchAnalyticsPageTablePager extends WatchAnalyticsTablePager {
 			$titleNsText = $title->getNsText();
 			if ( $titleNsText === '' ) {
 				$titleFullText = $title->getText();
-			}
-			else {
+			} else {
 				$titleFullText = $titleNsText . ':' . $title->getText();
 			}
 
 			$pageLink = Xml::element(
 				'a',
-				array( 'href' => $titleURL ),
+				[ 'href' => $titleURL ],
 				$titleFullText
 			);
 
-
 			// FIXME: page stats not currently enabled. Uncomment when enabled
-			$url = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( array(
+			$url = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( [
 				'page' => $title->getPrefixedText()
-			) );
+			] );
 			$msg = wfMessage( 'watchanalytics-view-page-stats' );
 			$pageStatsLink = Xml::element(
 				'a',
-				array( 'href' => $url ),
+				[ 'href' => $url ],
 				$msg
 			);
 
-
 			$pageLink .= ' <small>(' . $pageStatsLink . ' | ' . WatchSuggest::getWatchLink( $title ) . ')</small>';
 
-
 			return $pageLink;
-		}
-		else if ( $fieldName === 'max_pending_minutes' || $fieldName === 'avg_pending_minutes' ) {
-			return ( $value === NULL ) ? NULL : $this->watchQuery->createTimeStringFromMinutes( $value );
-		}
-		else {
+		} elseif ( $fieldName === 'max_pending_minutes' || $fieldName === 'avg_pending_minutes' ) {
+			return ( $value === null ) ? null : $this->watchQuery->createTimeStringFromMinutes( $value );
+		} else {
 			return $value;
 		}
-
 	}
 
 	public function getFieldNames() {
 		return $this->watchQuery->getFieldNames();
 	}
 
-	public function getDefaultSort () {
+	public function getDefaultSort() {
 		return 'num_reviewed';
 	}
 

--- a/includes/WatchAnalyticsParserFunctions.php
+++ b/includes/WatchAnalyticsParserFunctions.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchAnalyticsParserFunctions {
 

--- a/includes/WatchAnalyticsTablePager.php
+++ b/includes/WatchAnalyticsTablePager.php
@@ -58,12 +58,12 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 	 * Do a query with specified parameters, rather than using the object
 	 * context
 	 *
-	 * @param int $offset index offset, inclusive
+	 * @param string $offset index offset, inclusive
 	 * @param int $limit exact query limit
 	 * @param bool $descending Boolean: query direction, false for ascending, true for descending
 	 * @return ResultWrapper
 	 */
-	public function reallyDoQuery( int $offset, int $limit, bool $descending ) {
+	public function reallyDoQuery( $offset, $limit, $descending ) {
 		$qInfo = $this->getQueryInfo( $offset, $limit, $descending );
 		$tables = $qInfo['tables'];
 		$fields = $qInfo['fields'];

--- a/includes/WatchAnalyticsTablePager.php
+++ b/includes/WatchAnalyticsTablePager.php
@@ -2,7 +2,7 @@
 
 abstract class WatchAnalyticsTablePager extends TablePager {
 
-	public function __construct( $page, $conds, $filters = array() ) {
+	public function __construct( $page, $conds, $filters = [] ) {
 		$this->page = $page;
 		$this->limit = $page->limit;
 		$this->offset = $page->offset;
@@ -32,32 +32,27 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 	}
 
 	public function getIndexField() {
-
 		global $wgRequest;
 
 		$sortField = $wgRequest->getVal( 'sort' );
 		if ( isset( $sortField ) && $this->isFieldSortable( $sortField ) ) {
 			return $sortField;
-		}
-		else {
+		} else {
 			return $this->getDefaultSort();
 		}
-
 	}
 
 	public function isNavigationBarShown() {
 		return true;
 	}
 
-	public function isFieldSortable ( $field ) {
+	public function isFieldSortable( $field ) {
 		if ( ! isset( $this->isSortable[$field] ) ) {
 			return false;
-		}
-		else {
+		} else {
 			return $this->isSortable[ $field ];
 		}
 	}
-
 
 	/**
 	 * Do a query with specified parameters, rather than using the object
@@ -78,18 +73,18 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 
 		// code below adapted from MW 1.22 core, Pager.php,
 		// IndexPager::buildQueryInfo()
-		$sortColumns = array_merge( array( $this->mIndexField ), $this->mExtraSortFields );
+		$sortColumns = array_merge( [ $this->mIndexField ], $this->mExtraSortFields );
 		if ( $descending ) {
 			$options['ORDER BY'] = $sortColumns;
 		} else {
-			$orderBy = array();
+			$orderBy = [];
 			foreach ( $sortColumns as $col ) {
 				$orderBy[] = $col . ' DESC';
 			}
 			$options['ORDER BY'] = $orderBy;
 		}
 		if ( $offset != '' ) {
-			if ( intval ( $offset ) < 0 ) {
+			if ( intval( $offset ) < 0 ) {
 				$offset = 0;
 			}
 			$options['OFFSET'] = $offset;
@@ -97,10 +92,9 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 		$options['LIMIT'] = intval( $limit );
 		// end adapted code
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		return $dbr->select( $tables, $fields, $conds, __METHOD__, $options, $join_conds );
 	}
-
 
 	/**
 	 * Override IndexPager in includes/Pager.php.
@@ -115,17 +109,14 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 
 		if ( isset( $this->offset ) ) {
 			$offset = $this->offset;
-		}
-		else {
+		} else {
 			$offset = 0;
 		}
-
 
 		if ( $offset <= 0 ) {
 			$queries['prev'] = false;
 			$queries['first'] = false;
-		}
-		else if ( isset( $queries['prev']['offset'] ) ) {
+		} elseif ( isset( $queries['prev']['offset'] ) ) {
 			$queries['prev']['offset'] = $offset - $this->limit;
 		}
 
@@ -134,9 +125,7 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 		}
 
 		return $queries;
-
 	}
-
 
 	/**
 	 * Creates form to filter Watch Analytics results (e.g. by user group or
@@ -150,14 +139,13 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 		global $wgScript;
 
 		// user group filter
-		$groups = array( $this->msg( 'watchanalytics-user-group-no-filter' )->text() => '' );
+		$groups = [ $this->msg( 'watchanalytics-user-group-no-filter' )->text() => '' ];
 		$rawGroups = User::getAllGroups();
 		foreach ( $rawGroups as $group ) {
 			$labelMsg = $this->msg( 'group-' . $group );
 			if ( $labelMsg->exists() ) {
 				$label = $labelMsg->text();
-			}
-			else {
+			} else {
 				$label = $group;
 			}
 			$groups[ $label ] = $group;
@@ -166,15 +154,15 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 		$groupFilter->addOptions( $groups );
 
 		// category filter
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$result = $dbr->select(
 			'categorylinks',
 			'cl_to',
 			'',
 			__METHOD__,
-			array( 'DISTINCT' )
+			[ 'DISTINCT' ]
 		);
-		$categories = array( $this->msg( 'watchanalytics-category-no-filter' )->text() => '' );
+		$categories = [ $this->msg( 'watchanalytics-category-no-filter' )->text() => '' ];
 		while ( $row = $result->fetchRow() ) {
 			$category = Category::newFromName( $row['cl_to'] );
 			$label = $category->getTitle()->getText();
@@ -186,7 +174,7 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 
 		$out =
 			// create the form element
-			Xml::openElement( 'form', array( 'method' => 'get', 'action' => $wgScript, 'id' => 'ext-watchanalytics-form' ) ) .
+			Xml::openElement( 'form', [ 'method' => 'get', 'action' => $wgScript, 'id' => 'ext-watchanalytics-form' ] ) .
 
 			// create fieldset
 			Xml::fieldset( $this->msg( 'allmessages-filter-legend' )->text() ) .
@@ -195,8 +183,7 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 			Html::hidden( 'title', $this->getTitle()->getPrefixedText() ) .
 
 			// create table for form elements
-			Xml::openElement( 'table', array( 'class' => 'ext-watchanalytics-stats-filter-table' ) ) . "\n" .
-
+			Xml::openElement( 'table', [ 'class' => 'ext-watchanalytics-stats-filter-table' ] ) . "\n" .
 
 			// filter results by user group
 			'<tr>
@@ -247,7 +234,7 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 
 			// FIXME: are all of these needed? are additional need to support
 			// WatchAnalytics fields?
-			$this->getHiddenFields( array( 'title', 'prefix', 'filter', 'lang', 'limit', 'groupfilter', 'categoryfilter' ) ) .
+			$this->getHiddenFields( [ 'title', 'prefix', 'filter', 'lang', 'limit', 'groupfilter', 'categoryfilter' ] ) .
 
 			// close fieldset and form elements
 			Xml::closeElement( 'fieldset' ) .

--- a/includes/WatchAnalyticsTablePager.php
+++ b/includes/WatchAnalyticsTablePager.php
@@ -58,12 +58,12 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 	 * Do a query with specified parameters, rather than using the object
 	 * context
 	 *
-	 * @param string $offset index offset, inclusive
-	 * @param $limit Integer: exact query limit
-	 * @param $descending Boolean: query direction, false for ascending, true for descending
+	 * @param int $offset index offset, inclusive
+	 * @param int $limit exact query limit
+	 * @param bool $descending Boolean: query direction, false for ascending, true for descending
 	 * @return ResultWrapper
 	 */
-	public function reallyDoQuery( $offset, $limit, $descending ) {
+	public function reallyDoQuery( int $offset, int $limit, bool $descending ) {
 		$qInfo = $this->getQueryInfo( $offset, $limit, $descending );
 		$tables = $qInfo['tables'];
 		$fields = $qInfo['fields'];
@@ -134,6 +134,8 @@ abstract class WatchAnalyticsTablePager extends TablePager {
 	 * FIXME: this is the ugly method taken from SpecialAllmessages...I'm
 	 * hoping MW has a better way (templating engine?) to do this now than it
 	 * did when SpecialAllmessages was created...
+	 *
+	 * @return string
 	 */
 	public function buildForm() {
 		global $wgScript;

--- a/includes/WatchAnalyticsUserTablePager.php
+++ b/includes/WatchAnalyticsUserTablePager.php
@@ -2,7 +2,7 @@
 
 class WatchAnalyticsUserTablePager extends WatchAnalyticsTablePager {
 
-	protected $isSortable = array(
+	protected $isSortable = [
 		'user_name' => true,
 		'num_watches' => true,
 		'num_pending' => true,
@@ -10,9 +10,9 @@ class WatchAnalyticsUserTablePager extends WatchAnalyticsTablePager {
 		'max_pending_minutes' => true,
 		'avg_pending_minutes' => true,
 		'engagement_score' => true,
-	);
+	];
 
-	public function __construct( $page, $conds, $filters = array() ) {
+	public function __construct( $page, $conds, $filters = [] ) {
 		$this->watchQuery = new UserWatchesQuery();
 		parent::__construct( $page, $conds, $filters );
 	}
@@ -21,8 +21,7 @@ class WatchAnalyticsUserTablePager extends WatchAnalyticsTablePager {
 		return $this->watchQuery->getQueryInfo();
 	}
 
-	public function formatValue ( $fieldName , $value ) {
-
+	public function formatValue( $fieldName, $value ) {
 		if ( $fieldName === 'user_name' ) {
 
 			$user_name = $value;
@@ -39,32 +38,29 @@ class WatchAnalyticsUserTablePager extends WatchAnalyticsTablePager {
 			*/
 
 			$url = Title::newFromText( 'Special:PendingReviews' )->getLocalUrl(
-				array( 'user' => $user_name )
+				[ 'user' => $user_name ]
 			);
 			$msg = wfMessage( 'watchanalytics-view-user-pendingreviews' );
 
 			$name .= ' (' . Xml::element(
 				'a',
-				array( 'href' => $url ),
+				[ 'href' => $url ],
 				$msg
 			) . ')';
 
 			return $name;
-		}
-		else if ( $fieldName === 'max_pending_minutes' || $fieldName === 'avg_pending_minutes' ) {
-			return ( $value === NULL ) ? NULL : $this->watchQuery->createTimeStringFromMinutes( $value );
-		}
-		else {
+		} elseif ( $fieldName === 'max_pending_minutes' || $fieldName === 'avg_pending_minutes' ) {
+			return ( $value === null ) ? null : $this->watchQuery->createTimeStringFromMinutes( $value );
+		} else {
 			return $value;
 		}
-
 	}
 
 	public function getFieldNames() {
 		return $this->watchQuery->getFieldNames();
 	}
 
-	public function getDefaultSort () {
+	public function getDefaultSort() {
 		return 'num_pending';
 	}
 

--- a/includes/WatchAnalyticsWikiTablePager.php
+++ b/includes/WatchAnalyticsWikiTablePager.php
@@ -2,7 +2,7 @@
 
 class WatchAnalyticsWikiTablePager extends WatchAnalyticsTablePager {
 
-	protected $isSortable = array(
+	protected $isSortable = [
 		'tracking_timestamp' => true,
 
 		'num_pages' => true,
@@ -26,12 +26,12 @@ class WatchAnalyticsWikiTablePager extends WatchAnalyticsTablePager {
 		'content_num_one_watched' => true,
 		'content_num_unreviewed' => true,
 		'content_num_one_reviewed' => true,
-	);
+	];
 
 	public function __construct( $page, $conds ) {
 		$this->watchQuery = new WikiWatchesQuery();
 
-		parent::__construct( $page , $conds );
+		parent::__construct( $page, $conds );
 
 		global $wgRequest;
 
@@ -40,40 +40,36 @@ class WatchAnalyticsWikiTablePager extends WatchAnalyticsTablePager {
 			$this->mDefaultDirection = false;
 		}
 
-		$this->mExtraSortFields = array();
+		$this->mExtraSortFields = [];
 	}
 
 	public function getQueryInfo() {
 		return $this->watchQuery->getQueryInfo();
 	}
 
-	public function formatValue ( $fieldName , $value ) {
-
-		$timeDiffFields = array(
+	public function formatValue( $fieldName, $value ) {
+		$timeDiffFields = [
 			'max_pending_minutes',
 			'avg_pending_minutes',
 			'content_max_pending_minutes',
 			'content_avg_pending_minutes',
-		);
+		];
 
 		if ( in_array( $fieldName, $timeDiffFields ) ) {
-			return ( $value === NULL ) ? NULL : $this->watchQuery->createTimeStringFromMinutes( $value );
-		}
-		else if ( $fieldName === 'tracking_timestamp' ) {
+			return ( $value === null ) ? null : $this->watchQuery->createTimeStringFromMinutes( $value );
+		} elseif ( $fieldName === 'tracking_timestamp' ) {
 			$ts = new MWTimestamp( $value );
 			return $ts->format( 'Y-m-d' ) . '<br />' . $ts->format( 'H:i:s' );
-		}
-		else {
+		} else {
 			return $value;
 		}
-
 	}
 
 	public function getFieldNames() {
 		return $this->watchQuery->getFieldNames();
 	}
 
-	public function getDefaultSort () {
+	public function getDefaultSort() {
 		return 'tracking_timestamp';
 	}
 
@@ -84,7 +80,7 @@ class WatchAnalyticsWikiTablePager extends WatchAnalyticsTablePager {
 	 *
 	 * @return string empty string
 	 */
-	public function buildForm () {
+	public function buildForm() {
 		return '';
 	}
 }

--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchStateRecorder {
 
@@ -297,10 +264,13 @@ class WatchStateRecorder {
 	/**
 	 * Record relevant info in watch_tracking_page and watch_tracking_user
 	 * after a change to a page (e.g. an edit, a move, etc)
+	 *
+	 * @param WikiPage $wikipage
+	 * @return bool
 	 */
-	public static function recordPageChange( $article ) {
+	public static function recordPageChange( WikiPage $wikipage ) {
 		$timestamp = date( "YmdHis", time() );
-		$title = $article->getTitle();
+		$title = $wikipage->getTitle();
 
 		// page watch stats
 		list( $numWatchers, $numReviewed, $userIdArray ) = self::getPageWatchInfo( $title );

--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -38,8 +38,7 @@ class WatchStateRecorder {
 	protected $dbr;
 	protected $dbw;
 
-	public function recordedWithinHours ( $withinHours = 1 ) {
-
+	public function recordedWithinHours( $withinHours = 1 ) {
 		$withinHours = ( intval( $withinHours ) > 0 ) ? intval( $withinHours ) : 1;
 		$withinDays = floor( $withinHours / 24 );
 		if ( $withinDays > 0 ) {
@@ -56,31 +55,27 @@ class WatchStateRecorder {
 		return true;
 	}
 
-	public function getLatestAllWikiTimestamp () {
-
-		$dbr = wfGetDB( DB_SLAVE );
+	public function getLatestAllWikiTimestamp() {
+		$dbr = wfGetDB( DB_REPLICA );
 		$result = $dbr->selectRow(
 			'watch_tracking_wiki',
 			'tracking_timestamp',
 			'', // conds
 			__METHOD__,
-			array(
+			[
 				'LIMIT' => 1,
 				'ORDER BY' => 'tracking_timestamp DESC',
-			),
+			],
 			null // join_conds
 		);
 		if ( $result && $result->tracking_timestamp ) {
 			return new MWTimestamp( $result->tracking_timestamp );
-		}
-		else {
+		} else {
 			return new MWTimestamp( '19700101000000' );
 		}
-
 	}
 
 	public function recordAll() {
-
 		$this->dbw = wfGetDB( DB_MASTER );
 
 		// get user and page info
@@ -91,25 +86,24 @@ class WatchStateRecorder {
 		$pageQueryInfo = $pageWatchQuery->getQueryInfo();
 
 		// override fields
-		$userQueryInfo['fields'] = array(
+		$userQueryInfo['fields'] = [
 			'u.user_id AS user_id',
 			$userWatchQuery->sqlNumWatches,
 			$userWatchQuery->sqlNumPending,
-		);
-		$pageQueryInfo['fields'] = array(
+		];
+		$pageQueryInfo['fields'] = [
 			'p.page_id AS page_id',
 			'p.page_namespace AS page_namespace', // needed only for all-wiki info
 			$pageWatchQuery->sqlNumWatches,
 			$pageWatchQuery->sqlNumReviewed,
-		);
+		];
 
-
-		$users = $this->fetchAllFromQueryInfo( $userQueryInfo, array(
+		$users = $this->fetchAllFromQueryInfo( $userQueryInfo, [
 			'user_id', 'num_watches', 'num_pending'
-		) );
-		$pages = $this->fetchAllFromQueryInfo( $pageQueryInfo, array(
+		] );
+		$pages = $this->fetchAllFromQueryInfo( $pageQueryInfo, [
 			'page_id', 'page_namespace', 'num_watches', 'num_reviewed'
-		) );
+		] );
 
 		$now = new MWTimestamp();
 		$now = $now->format( 'YmdHis' );
@@ -140,8 +134,7 @@ class WatchStateRecorder {
 				if ( $pageNS === NS_MAIN ) {
 					$nsMainUnwatched++;
 				}
-			}
-			else if ( $numWatches === 1 ) {
+			} elseif ( $numWatches === 1 ) {
 				$oneWatched++;
 				if ( $pageNS === NS_MAIN ) {
 					$nsMainOneWatched++;
@@ -153,8 +146,7 @@ class WatchStateRecorder {
 				if ( $pageNS === NS_MAIN ) {
 					$nsMainUnreviewed++;
 				}
-			}
-			else if ( $numReviewed === 1 ) {
+			} elseif ( $numReviewed === 1 ) {
 				$oneReviewed++;
 				if ( $pageNS === NS_MAIN ) {
 					$nsMainOneReviewed++;
@@ -173,21 +165,21 @@ class WatchStateRecorder {
 			__METHOD__
 		);
 
-        foreach ( array_chunk( $pages, 100 ) as $chunk ) {
-            $this->dbw->insert(
-                'watch_tracking_page',
-                $chunk,
-                __METHOD__
-            );
-        }
+		foreach ( array_chunk( $pages, 100 ) as $chunk ) {
+			$this->dbw->insert(
+				'watch_tracking_page',
+				$chunk,
+				__METHOD__
+			);
+		}
 
 		// Get all wiki info
 		$allWikiQueryInfo = $this->getWikiQueryInfo();
 		$mainWikiQueryInfo = $this->getWikiQueryInfo( NS_MAIN, 'content_' );
 
-		$allNamespaces = $this->fetchAllFromQueryInfo( $allWikiQueryInfo, array(
+		$allNamespaces = $this->fetchAllFromQueryInfo( $allWikiQueryInfo, [
 			'num_pages', 'num_watches', 'num_pending', 'max_pending_minutes', 'avg_pending_minutes'
-		) );
+		] );
 
 		$allNamespaces[0][ 'max_pending_minutes' ] =
 			$allNamespaces[0][ 'max_pending_minutes' ]
@@ -197,10 +189,10 @@ class WatchStateRecorder {
 			$allNamespaces[0][ 'avg_pending_minutes' ]
 			? $allNamespaces[0][ 'avg_pending_minutes' ] : 0;
 
-		$contentOnly = $this->fetchAllFromQueryInfo( $mainWikiQueryInfo, array(
+		$contentOnly = $this->fetchAllFromQueryInfo( $mainWikiQueryInfo, [
 			'content_num_pages', 'content_num_watches', 'content_num_pending',
 			'content_max_pending_minutes', 'content_avg_pending_minutes'
-		) );
+		] );
 
 		$contentOnly[0][ 'content_max_pending_minutes' ] =
 			$contentOnly[0][ 'content_max_pending_minutes' ]
@@ -210,8 +202,7 @@ class WatchStateRecorder {
 			$contentOnly[0][ 'content_avg_pending_minutes' ]
 			? $contentOnly[0][ 'content_avg_pending_minutes' ] : 0;
 
-
-		$allWikiAnalytics = $allNamespaces[0] + $contentOnly[0] + array(
+		$allWikiAnalytics = $allNamespaces[0] + $contentOnly[0] + [
 			'tracking_timestamp' => $now,
 
 			'num_unwatched' => $unwatched,
@@ -223,7 +214,7 @@ class WatchStateRecorder {
 			'content_num_one_watched' => $nsMainOneWatched,
 			'content_num_unreviewed' => $nsMainUnreviewed,
 			'content_num_one_reviewed' => $nsMainOneReviewed,
-		);
+		];
 
 		$this->dbw->insert(
 			'watch_tracking_wiki',
@@ -234,7 +225,7 @@ class WatchStateRecorder {
 		return true;
 	}
 
-	public function fetchAllFromQueryInfo ( $queryInfo, $columnsToKeep ) {
+	public function fetchAllFromQueryInfo( $queryInfo, $columnsToKeep ) {
 		$result = $this->dbw->select(
 			$queryInfo['tables'],
 			$queryInfo['fields'],
@@ -244,7 +235,7 @@ class WatchStateRecorder {
 			$queryInfo['join_conds']
 		);
 
-		$output = array();
+		$output = [];
 
 		while ( $row = $result->fetchRow() ) {
 			$c = count( $output );
@@ -256,51 +247,49 @@ class WatchStateRecorder {
 		return $output;
 	}
 
-	public function getWikiQueryInfo ( $namespace = false, $prefix = '' ) {
-
+	public function getWikiQueryInfo( $namespace = false, $prefix = '' ) {
 		$sqlNumPages = "COUNT( DISTINCT p.page_id ) AS {$prefix}num_pages";
 		$sqlNumWatches = "SUM( IF( w.wl_title IS NOT NULL,             1, 0) ) AS {$prefix}num_watches";
 		$sqlNumPending = "SUM( IF( w.wl_notificationtimestamp IS NULL, 0, 1) ) AS {$prefix}num_pending";
 		$sqlMaxPendingMins = "MAX( TIMESTAMPDIFF(MINUTE, w.wl_notificationtimestamp, UTC_TIMESTAMP()) ) AS {$prefix}max_pending_minutes";
 		$sqlAvgPendingMins = "AVG( TIMESTAMPDIFF(MINUTE, w.wl_notificationtimestamp, UTC_TIMESTAMP()) ) AS {$prefix}avg_pending_minutes";
 
-
-		$tables = array(
+		$tables = [
 			'w' => 'watchlist',
 			'p' => 'page',
-		);
+		];
 
-		$fields = array(
+		$fields = [
 			$sqlNumPages,
 			$sqlNumWatches,
 			$sqlNumPending,
 			$sqlMaxPendingMins,
 			$sqlAvgPendingMins,
-		);
+		];
 
-		$join_conds = array(
-			'p' => array(
+		$join_conds = [
+			'p' => [
 				'RIGHT JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
-			),
-		);
+			],
+		];
 
-		$options = array(
+		$options = [
 			// unlike pages, group by NOTHING
 			// 'GROUP BY' => 'p.page_title, p.page_namespace'
-		);
+		];
 
 		$conds = '';
 		if ( $namespace !== false ) {
 			$conds = 'p.page_namespace=' . $namespace;
 		}
 
-		$return = array(
+		$return = [
 			'tables' => $tables,
 			'fields' => $fields,
 			'join_conds' => $join_conds,
 			'conds' => $conds,
 			'options' => $options,
-		);
+		];
 
 		return $return;
 	}
@@ -309,43 +298,40 @@ class WatchStateRecorder {
 	 * Record relevant info in watch_tracking_page and watch_tracking_user
 	 * after a change to a page (e.g. an edit, a move, etc)
 	 */
-	static public function recordPageChange ( $article ) {
-
+	public static function recordPageChange( $article ) {
 		$timestamp = date( "YmdHis", time() );
 		$title = $article->getTitle();
 
 		// page watch stats
 		list( $numWatchers, $numReviewed, $userIdArray ) = self::getPageWatchInfo( $title );
 
-
 		// query for each users' total watches/reviews
 		$userWQ = new UserWatchesQuery();
 		$userWatchStats = $userWQ->getMultiUserWatchStats( $userIdArray );
-		$userInsertData = array();
+		$userInsertData = [];
 		foreach ( $userWatchStats as $uData ) {
-			$userInsertData[] = array(
+			$userInsertData[] = [
 				'tracking_timestamp' => $timestamp,
 				'user_id' => $uData->wl_user,
 				'num_watches' => $uData->num_watches,
 				'num_pending' => $uData->num_pending,
-			);
+			];
 		}
-
 
 		$dbw = wfGetDB( DB_MASTER );
 
 		// insert into watch_tracking_page: $timestamp, $title->getId(), $numWatchers, $numReviewed
 		$dbw->replace(
 			'watch_tracking_page',
-			array( array( 'tracking_timestamp', 'page_id' ) ),
-			array(
-				array(
+			[ [ 'tracking_timestamp', 'page_id' ] ],
+			[
+				[
 					'tracking_timestamp' => $timestamp,
 					'page_id' => $title->getArticleID(),
 					'num_watches' => $numWatchers,
 					'num_reviewed' => $numReviewed,
-				),
-			),
+				],
+			],
 			__METHOD__
 		);
 
@@ -354,7 +340,7 @@ class WatchStateRecorder {
 		// watched to unwatched or unwatched to watched during the edit...maybe.
 		$dbw->replace(
 			'watch_tracking_user',
-			array( array( 'tracking_timestamp', 'user_id' ) ),
+			[ [ 'tracking_timestamp', 'user_id' ] ],
 			$userInsertData,
 			__METHOD__
 		);
@@ -364,15 +350,13 @@ class WatchStateRecorder {
 		// all buildable by page table, except avg/max time
 
 		return true;
-
 	}
 
-	static public function recordReview ( User $user, Title $title ) {
-
+	public static function recordReview( User $user, Title $title ) {
 		$timestamp = date( 'YmdHis', time() );
 
 		$userWQ = new UserWatchesQuery();
-		$userWatchStats = $userWQ->getMultiUserWatchStats( array( $user->getId() ) );
+		$userWatchStats = $userWQ->getMultiUserWatchStats( [ $user->getId() ] );
 
 		$dbw = wfGetDB( DB_MASTER );
 
@@ -382,13 +366,13 @@ class WatchStateRecorder {
 		// hasn't been cleared yet, suggesting it should be cleared again
 		$dbw->replace(
 			'watch_tracking_user',
-			array( array( 'tracking_timestamp', 'user_id' ) ),
-			array(
+			[ [ 'tracking_timestamp', 'user_id' ] ],
+			[
 				'tracking_timestamp' => $timestamp,
 				'user_id' => $userWatchStats[0]->wl_user,
 				'num_watches' => $userWatchStats[0]->num_watches,
 				'num_pending' => $userWatchStats[0]->num_pending,
-			),
+			],
 			__METHOD__
 		);
 
@@ -397,22 +381,20 @@ class WatchStateRecorder {
 
 		$dbw->replace(
 			'watch_tracking_page',
-			array( array( 'tracking_timestamp', 'page_id' ) ),
-			array(
+			[ [ 'tracking_timestamp', 'page_id' ] ],
+			[
 				'tracking_timestamp' => $timestamp,
 				'page_id' => $title->getArticleID(),
 				'num_watches' => $numWatchers,
 				'num_reviewed' => $numReviewed,
-			),
+			],
 			__METHOD__
 		);
 
 		return true;
-
 	}
 
-	static public function getPageWatchInfo ( Title $title ) {
-
+	public static function getPageWatchInfo( Title $title ) {
 		// query for page watchers
 		$pageWQ = new PageWatchesQuery();
 		$watchers = $pageWQ->getPageWatchers( $title->getDBkey(), $title->getNamespace() );
@@ -420,15 +402,15 @@ class WatchStateRecorder {
 		// PHP count num watchers and reviewers (watchers could change if user (un)checks "watch this page" box)
 		$numWatchers = count( $watchers );
 		$numReviewed = 0;
-		$userIdArray = array();
+		$userIdArray = [];
 		foreach ( $watchers as $w ) {
-			if ( $w->wl_notificationtimestamp === NULL ) {
+			if ( $w->wl_notificationtimestamp === null ) {
 				$numReviewed++;
 			}
 			$userIdArray[] = $w->wl_user;
 		}
 
-		return array( $numWatchers, $numReviewed, $userIdArray );
+		return [ $numWatchers, $numReviewed, $userIdArray ];
 	}
 
 }

--- a/includes/WatchSuggest.php
+++ b/includes/WatchSuggest.php
@@ -163,11 +163,9 @@ class WatchSuggest {
 
 		if ( count( $namespaces ) > 1 ) {
 			$namespaceCondition = 'AND p.page_namespace IN (' . $this->dbr->makeList( $namespaces ) . ')';
-		}
-		elseif ( count( $namespaces ) === 1 ) {
+		} elseif ( count( $namespaces ) === 1 ) {
 			$namespaceCondition = 'AND p.page_namespace = ' . $namespaces[0];
-		}
-		else {
+		} else {
 			$namespaceCondition = '';
 		}
 
@@ -267,15 +265,13 @@ class WatchSuggest {
 		while ( $row = $linkedPagesResult->fetchObject() ) {
 			if ( ! isset( $linkedPages[ $row->pl_from_id ] ) ) {
 				$linkedPages[ $row->pl_from_id ] = 1;
-			}
-			else {
+			} else {
 				$linkedPages[ $row->pl_from_id ]++;
 			}
 
 			if ( ! isset( $linkedPages[ $row->pl_to_id ] ) ) {
 				$linkedPages[ $row->pl_to_id ] = 1;
-			}
-			else {
+			} else {
 				$linkedPages[ $row->pl_to_id ]++;
 			}
 		}
@@ -299,8 +295,7 @@ class WatchSuggest {
 			if ( isset( $pageData[ 'num_watches' ] ) ) {
 				$numWatches = intval( $pageData[ 'num_watches' ] );
 				$numViews = intval( $pageData[ 'num_views' ] );
-			}
-			else {
+			} else {
 				$numWatches = 0;
 				$numViews = 0;
 			}

--- a/includes/WatchSuggest.php
+++ b/includes/WatchSuggest.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -45,9 +45,9 @@ class WatchSuggest {
 	 */
 	public $dbr;
 
-	public function __construct ( User $user ) {
+	public function __construct( User $user ) {
 		$this->mUser = $user;
-		$this->dbr = wfGetDB( DB_SLAVE );
+		$this->dbr = wfGetDB( DB_REPLICA );
 	}
 
 	/**
@@ -55,20 +55,18 @@ class WatchSuggest {
 	 *
 	 * @return bool
 	 */
-	public function getWatchSuggestionList () {
-
+	public function getWatchSuggestionList() {
 		$html = '';
 
 		// gets id, NS and title of all pages in users watchlist in NS_MAIN
 		$userWatchlist = $this->getUserWatchlist( $this->mUser, NS_MAIN );
-		$linkedPages = array();
+		$linkedPages = [];
 
 		// if the user has pages from NS_MAIN in their watchlist then find all
 		// pages linked to/from those pages
 		if ( count( $userWatchlist ) > 0 ) {
 			$linkedPages = $this->getPagesRelatedByLinks( $userWatchlist );
 		}
-
 
 		if ( count( $linkedPages ) == 0 ) {
 
@@ -82,17 +80,15 @@ class WatchSuggest {
 				__METHOD__
 			);
 
-			$linkedPages = array();
+			$linkedPages = [];
 
 			// create "fake" $linkedPages where all pages in NS_MAIN are given the same number
 			// of inbound/outbound links from the users watchlist
 			while ( $row = $noWatchlist->fetchObject() ) {
-				$linkedPages[ $row->page_id ] = array( 'num_links' => 1 );
+				$linkedPages[ $row->page_id ] = [ 'num_links' => 1 ];
 			}
 
 		}
-
-
 
 		$pageWatchQuery = new PageWatchesQuery;
 		$pageWatchesAndViews = $pageWatchQuery->getPageWatchesAndViews( array_keys( $linkedPages ) );
@@ -105,11 +101,8 @@ class WatchSuggest {
 
 		$sortedPages = $this->sortPagesByWatchImportance( $linkedPages );
 
-
 		global $wgUser;
 		$userIsViewer = $wgUser->getId() == $this->mUser->getId();
-
-
 
 		$count = 1;
 		$watchSuggestionsTitle = wfMessage( 'pendingreviews-watch-suggestion-title' )->text();
@@ -117,7 +110,7 @@ class WatchSuggest {
 
 		global $egPendingReviewsNumberWatchSuggestions;
 
-		$watchSuggestionsLIs = array();
+		$watchSuggestionsLIs = [];
 		foreach ( $sortedPages as $pageId => $pageInfo ) {
 
 			$suggestedTitle = Title::newFromID( $pageInfo[ 'page_id' ] );
@@ -132,8 +125,7 @@ class WatchSuggest {
 
 			if ( $userIsViewer ) {
 				$watchLink = '<strong>' . self::getWatchLink( $suggestedTitle ) . ':</strong> ';
-			}
-			else {
+			} else {
 				$watchLink = '';
 			}
 
@@ -159,79 +151,72 @@ class WatchSuggest {
 			. WatchAnalyticsHtmlHelper::formatListArray( $this->getMostWatchesListArray( $numTopWatchers ), 2 );
 
 		return $html;
-
 	}
 
-
-
-	public function getUserWatchlist ( User $user, $namespaces = array() ) {
-
+	public function getUserWatchlist( User $user, $namespaces = [] ) {
 		if ( ! is_array( $namespaces ) ) {
 			if ( intval( $namespaces ) < 0 ) {
 				throw new MWException( __METHOD__ . ' argument $namespace requires integer or array' );
 			}
-			$namespaces = array( $namespaces );
+			$namespaces = [ $namespaces ];
 		}
 
 		if ( count( $namespaces ) > 1 ) {
 			$namespaceCondition = 'AND p.page_namespace IN (' . $this->dbr->makeList( $namespaces ) . ')';
 		}
-		else if ( count( $namespaces ) === 1 ) {
+ elseif ( count( $namespaces ) === 1 ) {
 			$namespaceCondition = 'AND p.page_namespace = ' . $namespaces[0];
-		}
-		else {
+	}
+ else {
 			$namespaceCondition = '';
-		}
+	}
 
 		$userId = $user->getId();
 
 		// SELECT
-		// 	p.page_id AS p_id,
-		// 	w.wl_title AS p_title
+		// p.page_id AS p_id,
+		// w.wl_title AS p_title
 		// FROM page AS p
 		// LEFT JOIN watchlist AS w
-		// 	ON (
-		// 		w.wl_namespace = p.page_namespace
-		// 		AND w.wl_title = p.page_title
-		// 	)
+		// ON (
+		// w.wl_namespace = p.page_namespace
+		// AND w.wl_title = p.page_title
+		// )
 		// WHERE
-		// 	w.wl_user = $userId
-		// 	AND p.page_namespace = 0
+		// w.wl_user = $userId
+		// AND p.page_namespace = 0
 		$userWatchlist = $this->dbr->select(
-			array(
+			[
 				'p' => 'page',
 				'w' => 'watchlist',
-			),
-			array(
+			],
+			[
 				'p.page_id AS p_id',
 				'w.wl_namespace AS p_namespace',
 				'w.wl_title AS p_title',
- 			),
+			],
 			"w.wl_user=$userId " . $namespaceCondition,
 			__METHOD__,
-			array(), // options
-			array(
-				'w' => array(
+			[], // options
+			[
+				'w' => [
 					'LEFT JOIN',
 					'w.wl_namespace = p.page_namespace AND w.wl_title = p.page_title'
-				)
-			)
+				]
+			]
 		);
 
-		$return = array();
+		$return = [];
 		while ( $row = $userWatchlist->fetchObject() ) {
 			$return[] = $row;
 		}
 
-
 		return $return;
 	}
 
-
-	public function getPagesRelatedByLinks ( $userWatchlist ) {
-
-		$userWatchlistPageIds = array();
-		$userWatchlistPageTitles = array();
+	public function getPagesRelatedByLinks( $userWatchlist ) {
+		$userWatchlistPageIds = [];
+		$userWatchlistPageTitles = [];
 		foreach ( $userWatchlist as $row ) {
 			$userWatchlistPageIds[] = $row->p_id;
 
@@ -244,42 +229,41 @@ class WatchSuggest {
 		$titles = $this->dbr->makeList( $userWatchlistPageTitles );
 
 		// SELECT
-		// 	pl.pl_from AS pl_from_id,
-		// 	p_to.page_id AS pl_to_id
+		// pl.pl_from AS pl_from_id,
+		// p_to.page_id AS pl_to_id
 		// FROM pagelinks AS pl
 		// INNER JOIN page AS p_to
-		// 	ON (
-		// 		pl.pl_namespace = p_to.page_namespace
-		// 		AND pl.pl_title = p_to.page_title
-		// 	)
+		// ON (
+		// pl.pl_namespace = p_to.page_namespace
+		// AND pl.pl_title = p_to.page_title
+		// )
 		// WHERE
-		// 	pl.pl_from IN ( <LIST OF all p_id found above> )
-		// 	OR ( pl.pl_namespace = 0 AND pl.pl_title IN ( <LIST OF ALL p_title found above> ) )
+		// pl.pl_from IN ( <LIST OF all p_id found above> )
+		// OR ( pl.pl_namespace = 0 AND pl.pl_title IN ( <LIST OF ALL p_title found above> ) )
 		$where =
 			"pl.pl_from IN ($ids) " .
 			" OR ( pl.pl_namespace = 0 AND pl.pl_title IN ($titles) )";
 
-
 		$linkedPagesResult = $this->dbr->select(
-			array(
+			[
 				'pl' => 'pagelinks',
 				'p_to' => 'page',
-			),
-			array(
+			],
+			[
 				'pl.pl_from AS pl_from_id',
 				'p_to.page_id AS pl_to_id',
- 			),
+			],
 			$where,
 			__METHOD__,
-			array(), // options
-			array(
-				'p_to' => array(
+			[], // options
+			[
+				'p_to' => [
 					'INNER JOIN',
 					'pl.pl_namespace = p_to.page_namespace AND pl.pl_title = p_to.page_title'
-				),
-			)
+				],
+			]
 		);
-		$linkedPages = array();
+		$linkedPages = [];
 		while ( $row = $linkedPagesResult->fetchObject() ) {
 			if ( ! isset( $linkedPages[ $row->pl_from_id ] ) ) {
 				$linkedPages[ $row->pl_from_id ] = 1;
@@ -296,24 +280,21 @@ class WatchSuggest {
 			}
 		}
 
-		$linkedPagesToKeep = array();
+		$linkedPagesToKeep = [];
 		foreach ( $linkedPages as $pageId => $numLinks ) {
 			if ( ! in_array( $pageId, $userWatchlistPageIds ) ) {
-				$linkedPagesToKeep[ $pageId ] = array( 'num_links' => $numLinks );
+				$linkedPagesToKeep[ $pageId ] = [ 'num_links' => $numLinks ];
 			}
 		}
 
 		return $linkedPagesToKeep;
-
 	}
 
-
-	public function sortPagesByWatchImportance ( $pages ) {
-
-		$watches = array();
-		$links = array();
-		$watchNeedArray = array();
-		$sortedPages = array();
+	public function sortPagesByWatchImportance( $pages ) {
+		$watches = [];
+		$links = [];
+		$watchNeedArray = [];
+		$sortedPages = [];
 		foreach ( $pages as $pageId => $pageData ) {
 			if ( isset( $pageData[ 'num_watches' ] ) ) {
 				$numWatches = intval( $pageData[ 'num_watches' ] );
@@ -327,13 +308,13 @@ class WatchSuggest {
 
 			$watchNeed = $numLinks * pow( $numViews, 2 );
 
-			$sortedPages[] = array(
+			$sortedPages[] = [
 				'page_id' => $pageId,
 				'num_watches' => $numWatches,
 				'num_links' => $numLinks,
 				'num_views' => $numViews,
 				'watch_need' => $watchNeed,
-			);
+			];
 			$watches[] = $numWatches;
 			$links[] = $numLinks;
 			$watchNeedArray[] = $watchNeed;
@@ -344,61 +325,60 @@ class WatchSuggest {
 	}
 
 	// SELECT
-	// 	u.user_name AS uname,
-	// 	u.user_real_name AS name,
-	// 	COUNT( * ) AS user_watches
+	// u.user_name AS uname,
+	// u.user_real_name AS name,
+	// COUNT( * ) AS user_watches
 	// FROM
-	// 	watchlist AS w
+	// watchlist AS w
 	// RIGHT JOIN page AS p ON
-	// 	(w.wl_namespace = p.page_namespace AND w.wl_title = p.page_title)
+	// (w.wl_namespace = p.page_namespace AND w.wl_title = p.page_title)
 	// LEFT JOIN user AS u ON
-	// 	(w.wl_user = u.user_id)
+	// (w.wl_user = u.user_id)
 	// WHERE
-	// 	p.page_is_redirect = 0
+	// p.page_is_redirect = 0
 	// GROUP BY w.wl_user
 	// ORDER BY user_watches DESC
-	public function getMostWatchesListArray ( $limit = 20 ) {
-
+	public function getMostWatchesListArray( $limit = 20 ) {
 		$mostWatches = $this->dbr->select(
-			array(
+			[
 				'w' => 'watchlist',
 				'p' => 'page',
 				'u' => 'user',
-			),
-			array(
+			],
+			[
 				'u.user_name AS user_name',
 				'u.user_real_name AS real_name',
 				'COUNT( * ) AS user_watches',
- 			),
+			],
 			'p.page_is_redirect = 0 AND w.wl_user != 0', // no redirects, and don't include maintenance scripts and other non-users
 			__METHOD__,
-			array(
+			[
 				'GROUP BY' => 'w.wl_user',
 				'ORDER BY' => 'user_watches DESC',
 				'LIMIT' => $limit,
-			),
-			array(
-				'p' => array(
+			],
+			[
+				'p' => [
 					'RIGHT JOIN',
 					'w.wl_namespace = p.page_namespace AND w.wl_title = p.page_title'
-				),
-				'u' => array(
+				],
+				'u' => [
 					'LEFT JOIN',
 					'w.wl_user = u.user_id'
-				),
-			)
+				],
+			]
 		);
 
-		$return = array();
+		$return = [];
 		$count = 0;
 		while ( $user = $mostWatches->fetchObject() ) {
 			$count++;
 			// CONSIDERING usering real name
 			// if ( $user->real_name ) {
-			// 	$displayName = $user->real_name;
+			// $displayName = $user->real_name;
 			// }
 			// else {
-			// 	$displayName = $user->user_name;
+			// $displayName = $user->user_name;
 			// }
 
 			$watchUser = User::newFromName( $user->user_name );
@@ -414,33 +394,30 @@ class WatchSuggest {
 		}
 
 		return $return;
-
 	}
 
-	public static function getWatchLink ( Title $title ) {
-
+	public static function getWatchLink( Title $title ) {
 		global $wgUser;
 
 		// action=watch&token=9d1186bca6dd20866e607538b92be6c8%2B%5C
-		$watchLinkURL = $title->getLinkURL( array(
+		$watchLinkURL = $title->getLinkURL( [
 			'action' => 'watch',
 			'token' => WatchAction::getWatchToken( $title, $wgUser ),
-		) );
+		] );
 
 		$watchLink =
 			Xml::element(
 				'a',
-				array(
+				[
 					'href' => $watchLinkURL,
 					'class' => 'pendingreviews-watch-suggest-link',
 					'suggest-title-prefixed-text' => $title->getPrefixedDBkey(),
 					'thanks-msg' => wfMessage( 'pendingreviews-watch-suggestion-thanks' )->text()// FIXME: there's a better way
-				),
+				],
 				wfMessage( 'pendingreviews-watch-suggestion-watchlink' )->text()
 			);
 
 		return $watchLink;
-
 	}
 
 }

--- a/includes/WatchSuggest.php
+++ b/includes/WatchSuggest.php
@@ -164,12 +164,12 @@ class WatchSuggest {
 		if ( count( $namespaces ) > 1 ) {
 			$namespaceCondition = 'AND p.page_namespace IN (' . $this->dbr->makeList( $namespaces ) . ')';
 		}
- elseif ( count( $namespaces ) === 1 ) {
+		elseif ( count( $namespaces ) === 1 ) {
 			$namespaceCondition = 'AND p.page_namespace = ' . $namespaces[0];
-	}
- else {
+		}
+		else {
 			$namespaceCondition = '';
-	}
+		}
 
 		$userId = $user->getId();
 

--- a/includes/WatchSuggest.php
+++ b/includes/WatchSuggest.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchSuggest {
 
@@ -319,20 +286,6 @@ class WatchSuggest {
 		return $sortedPages;
 	}
 
-	// SELECT
-	// u.user_name AS uname,
-	// u.user_real_name AS name,
-	// COUNT( * ) AS user_watches
-	// FROM
-	// watchlist AS w
-	// RIGHT JOIN page AS p ON
-	// (w.wl_namespace = p.page_namespace AND w.wl_title = p.page_title)
-	// LEFT JOIN user AS u ON
-	// (w.wl_user = u.user_id)
-	// WHERE
-	// p.page_is_redirect = 0
-	// GROUP BY w.wl_user
-	// ORDER BY user_watches DESC
 	public function getMostWatchesListArray( $limit = 20 ) {
 		$mostWatches = $this->dbr->select(
 			[

--- a/includes/WatchesQuery.php
+++ b/includes/WatchesQuery.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -79,12 +79,10 @@ class WatchesQuery {
 	 */
 	protected $categoryFilter = false;
 
-
-	public function __construct () {
+	public function __construct() {
 	}
 
-	public function createTimeStringFromMinutes ( $totalMinutes ) {
-
+	public function createTimeStringFromMinutes( $totalMinutes ) {
 		$remainder = $totalMinutes;
 
 		$minutesInDay = 60 * 24;
@@ -98,7 +96,7 @@ class WatchesQuery {
 
 		$minutes = $remainder;
 
-		$time = array();
+		$time = [];
 		if ( $days ) {
 			$time[] = $days . ' day' . ( ( $days > 1 ) ? 's' : '' );
 		}
@@ -118,7 +116,7 @@ class WatchesQuery {
 	}
 
 	public function getFieldNames() {
-		$output = array();
+		$output = [];
 
 		foreach ( $this->fieldNames as $dbKey => $msg ) {
 			$output[$dbKey] = wfMessage( $msg )->text();
@@ -128,45 +126,43 @@ class WatchesQuery {
 	}
 
 	public function getQueryInfo() {
+		$this->conds = $this->conds ? $this->conds : [];
 
-		$this->conds = $this->conds ? $this->conds : array();
-
-		if ( isset ( $this->limit ) ) {
+		if ( isset( $this->limit ) ) {
 			$this->options['LIMIT'] = $this->limit;
 		}
-		if ( isset ( $this->offset ) ) {
+		if ( isset( $this->offset ) ) {
 			$this->options['OFFSET'] = $this->offset;
 		}
 
-		$return = array(
+		$return = [
 			'tables' => $this->tables,
 			'fields' => $this->fields,
 			'join_conds' => $this->join_conds,
 			'conds' => $this->conds,
 			'options' => $this->options,
-		);
+		];
 
 		return $return;
-
 	}
 
-	public function setUserGroupFilter ( $ugf ) {
+	public function setUserGroupFilter( $ugf ) {
 		if ( $ugf ) {
 			$this->userGroupFilter = $ugf;
 		}
 	}
 
-	public function setCategoryFilter ( $cf ) {
+	public function setCategoryFilter( $cf ) {
 		if ( $cf ) {
 			$this->categoryFilter = $cf;
 		}
 	}
 
-	public function setCategoryFilterQueryInfo () {
+	public function setCategoryFilterQueryInfo() {
 		$this->tables['cat'] = 'categorylinks';
-		$this->join_conds['cat'] = array(
+		$this->join_conds['cat'] = [
 			'RIGHT JOIN', 'cat.cl_from = p.page_id AND cat.cl_to = "' . $this->categoryFilter . '"'
-		);
+		];
 	}
 
 }

--- a/includes/WatchesQuery.php
+++ b/includes/WatchesQuery.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WatchesQuery {
 

--- a/includes/WikiWatchesQuery.php
+++ b/includes/WikiWatchesQuery.php
@@ -1,37 +1,4 @@
 <?php
-/**
- * MediaWiki Extension: WatchAnalytics
- * http://www.mediawiki.org/wiki/Extension:WatchAnalytics
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * This program is distributed WITHOUT ANY WARRANTY.
- */
-
-/**
- *
- * @file
- * @ingroup Extensions
- * @author James Montalvo
- * @license MIT License
- */
-
-# Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
-if ( !defined( 'MEDIAWIKI' ) ) {
-	echo <<<EOT
-To install this extension, put the following line in LocalSettings.php:
-require_once( "$IP/extensions/WatchAnalytics/WatchAnalytics.php" );
-EOT;
-	exit( 1 );
-}
 
 class WikiWatchesQuery extends WatchesQuery {
 

--- a/includes/WikiWatchesQuery.php
+++ b/includes/WikiWatchesQuery.php
@@ -21,7 +21,7 @@
  * @file
  * @ingroup Extensions
  * @author James Montalvo
- * @licence MIT License
+ * @license MIT License
  */
 
 # Alert the user that this is not a valid entry point to MediaWiki if they try to access the special pages file directly.
@@ -35,14 +35,14 @@ EOT;
 
 class WikiWatchesQuery extends WatchesQuery {
 
-	protected $fieldNames = array(
+	protected $fieldNames = [
 		'tracking_timestamp'          => 'watchanalytics-special-header-timestamp',
 
 		'num_pages'                   => 'watchanalytics-special-header-num-pages',
-		'num_watches'                 =>   'watchanalytics-special-header-watches',
-		'num_pending'                 =>   'watchanalytics-special-header-pending-watches',
-		'max_pending_minutes'         =>   'watchanalytics-special-header-pending-maxtime',
-		'avg_pending_minutes'         =>   'watchanalytics-special-header-pending-averagetime',
+		'num_watches'                 => 'watchanalytics-special-header-watches',
+		'num_pending'                 => 'watchanalytics-special-header-pending-watches',
+		'max_pending_minutes'         => 'watchanalytics-special-header-pending-maxtime',
+		'avg_pending_minutes'         => 'watchanalytics-special-header-pending-averagetime',
 
 		'num_unwatched'               => 'watchanalytics-special-header-num-unwatched',
 		'num_one_watched'             => 'watchanalytics-special-header-num-one-watched',
@@ -59,15 +59,14 @@ class WikiWatchesQuery extends WatchesQuery {
 		// 'content_num_one_watched'     => 'watchanalytics-special-header-main-num-one-watched',
 		// 'content_num_unreviewed'      => 'watchanalytics-special-header-main-num-unreviewed',
 		// 'content_num_one_reviewed'    => 'watchanalytics-special-header-main-num-one-reviewed',
-	);
+	];
 
 	public function getQueryInfo( $conds = null ) {
-
-		$this->tables = array(
+		$this->tables = [
 			'w' => 'watch_tracking_wiki'
-		);
+		];
 
-		$this->fields = array(
+		$this->fields = [
 			'tracking_timestamp',
 
 			'num_pages',
@@ -91,16 +90,15 @@ class WikiWatchesQuery extends WatchesQuery {
 			// 'content_num_one_watched',
 			// 'content_num_unreviewed',
 			// 'content_num_one_reviewed',
-		);
+		];
 
-		$this->conds = $conds ? $conds : array();
+		$this->conds = $conds ? $conds : [];
 
-		$this->join_conds = array();
+		$this->join_conds = [];
 
-		$this->options = array();
+		$this->options = [];
 
 		return parent::getQueryInfo();
-
 	}
 
 }

--- a/maintenance/addCategoryToWatchlist.php
+++ b/maintenance/addCategoryToWatchlist.php
@@ -30,12 +30,12 @@
 // Allow people to have different layouts.
 if ( ! isset( $IP ) ) {
 	$IP = __DIR__ . '/../../../';
-	if ( getenv("MW_INSTALL_PATH") ) {
-		$IP = getenv("MW_INSTALL_PATH");
+	if ( getenv( "MW_INSTALL_PATH" ) ) {
+		$IP = getenv( "MW_INSTALL_PATH" );
 	}
 }
 
-require_once( "$IP/maintenance/Maintenance.php" );
+require_once "$IP/maintenance/Maintenance.php";
 
 class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 
@@ -62,10 +62,9 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 			true, true );
 
 		// $this->addOption(
-		// 	'dry-run',
-		// 	"List whether a page will be added to a user's watchlist, but do not perform action",
-		// 	false, true );
-
+		// 'dry-run',
+		// "List whether a page will be added to a user's watchlist, but do not perform action",
+		// false, true );
 	}
 
 	/**
@@ -83,12 +82,11 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 			foreach ( $namesArray as $i => $u ) {
 				$namesArray[$i] = trim( $u );
 			}
-		}
-		else {
+		} else {
 			die( 'You must supply at least one username' );
 		}
 
-		$users = array();
+		$users = [];
 		foreach ( $namesArray as $username ) {
 			$users[] = User::newFromName( $username );
 		}
@@ -99,8 +97,7 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 			foreach ( $catsArray as $i => $c ) {
 				$catsArray[$i] = trim( $c );
 			}
-		}
-		else {
+		} else {
 			die( 'You must supply at least one category' );
 		}
 
@@ -124,8 +121,7 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 
 					if ( $watchedItem->isWatched() ) {
 						$this->output( "already watching\n" );
-					}
-					else {
+					} else {
 						$watchedItem->addWatch();
 						$this->output( "added to watchlist\n" );
 					}
@@ -142,4 +138,4 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 }
 
 $maintClass = "WatchAnalyticsAddCategoryToWatchlist";
-require_once( DO_MAINTENANCE );
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/addCategoryToWatchlist.php
+++ b/maintenance/addCategoryToWatchlist.php
@@ -39,12 +39,6 @@ require_once "$IP/maintenance/Maintenance.php";
 
 class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 
-	/**
-	 * Add description
-	 *
-	 * @param string $varName add description
-	 * @return null
-	 */
 	public function __construct() {
 		parent::__construct();
 
@@ -67,12 +61,6 @@ class WatchAnalyticsAddCategoryToWatchlist extends Maintenance {
 		// false, true );
 	}
 
-	/**
-	 * Add description
-	 *
-	 * @param string $varName add description
-	 * @return null
-	 */
 	public function execute() {
 		$dbw = wfGetDB( DB_MASTER );
 

--- a/maintenance/forgivePendingReviews.php
+++ b/maintenance/forgivePendingReviews.php
@@ -65,30 +65,6 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 			false, true );
 	}
 
-	// $query =
-		// "SELECT
-			// u.user_name AS user_name,
-			// p.page_title AS title,
-			// w.wl_notificationtimestamp AS pending_since
-		// FROM watchlist AS w
-		// LEFT JOIN page AS p ON
-			// w.wl_title = p.page_title
-			// AND w.wl_namespace = p.page_namespace
-		// LEFT JOIN user AS u ON
-			// u.user_id = w.wl_user
-		// WHERE
-			// w.wl_notificationtimestamp IS NOT NULL
-			// AND w.wl_notificationtimestamp < $forgiveBefore
-			// AND (
-				// SELECT COUNT(*)
-				// FROM watchlist AS w2
-				// WHERE
-					// w.wl_namespace = w2.wl_namespace
-					// AND w.wl_title = w2.wl_title
-					// AND w2.wl_notificationtimestamp IS NULL
-			// ) >= $reviewedBy
-			// $usernames
-		// ORDER BY w.wl_notificationtimestamp DESC;";
 	public function execute() {
 		$dbw = wfGetDB( DB_MASTER );
 

--- a/maintenance/forgivePendingReviews.php
+++ b/maintenance/forgivePendingReviews.php
@@ -101,8 +101,7 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 
 			$namesForDB = $dbw->makeList( $namesArray );
 			$usernames = "AND u.user_name IN ($namesForDB)";
-		}
-		else {
+		} else {
 			$usernames = '';
 		}
 

--- a/maintenance/forgivePendingReviews.php
+++ b/maintenance/forgivePendingReviews.php
@@ -29,12 +29,12 @@
 // Allow people to have different layouts.
 if ( ! isset( $IP ) ) {
 	$IP = __DIR__ . '/../../../';
-	if ( getenv("MW_INSTALL_PATH") ) {
-		$IP = getenv("MW_INSTALL_PATH");
+	if ( getenv( "MW_INSTALL_PATH" ) ) {
+		$IP = getenv( "MW_INSTALL_PATH" );
 	}
 }
 
-require_once( "$IP/maintenance/Maintenance.php" );
+require_once "$IP/maintenance/Maintenance.php";
 
 class WatchAnalyticsForgivePendingReviews extends Maintenance {
 
@@ -63,7 +63,6 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 			'reviewedby',
 			'Limit forgiveness to pages which have been reviewed by at least the specified number of people (default ' . $this->forgiveBefore . ')',
 			false, true );
-
 	}
 
 	// $query =
@@ -107,7 +106,6 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 			$usernames = '';
 		}
 
-
 		$forgiveBefore = $this->getOption( 'forgivebefore', $this->forgiveBefore );
 		$reviewedBy = $this->getOption( 'reviewedby', $this->reviewedBy );
 
@@ -144,4 +142,4 @@ class WatchAnalyticsForgivePendingReviews extends Maintenance {
 }
 
 $maintClass = "WatchAnalyticsForgivePendingReviews";
-require_once( DO_MAINTENANCE );
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/watchAnalyticsRecordState.php
+++ b/maintenance/watchAnalyticsRecordState.php
@@ -29,12 +29,12 @@
 // Allow people to have different layouts.
 if ( ! isset( $IP ) ) {
 	$IP = __DIR__ . '/../../../';
-	if ( getenv("MW_INSTALL_PATH") ) {
-		$IP = getenv("MW_INSTALL_PATH");
+	if ( getenv( "MW_INSTALL_PATH" ) ) {
+		$IP = getenv( "MW_INSTALL_PATH" );
 	}
 }
 
-require_once( "$IP/maintenance/Maintenance.php" );
+require_once "$IP/maintenance/Maintenance.php";
 
 class WatchAnalyticsRecordState extends Maintenance {
 
@@ -52,4 +52,4 @@ class WatchAnalyticsRecordState extends Maintenance {
 }
 
 $maintClass = "WatchAnalyticsRecordState";
-require_once( DO_MAINTENANCE );
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/schema/WatchAnalyticsUpdaterHooks.php
+++ b/schema/WatchAnalyticsUpdaterHooks.php
@@ -10,7 +10,6 @@ class WatchAnalyticsUpdaterHooks {
 	}
 
 	public static function addSchemaUpdates( $updater = null ) {
-
 		// NOTE: this SQL file adds tables watch_tracking_user,
 		// watch_tracking_page and watch_tracking_wiki. Since no changes have
 		// been made to the database schema over the life of this extension so
@@ -21,7 +20,7 @@ class WatchAnalyticsUpdaterHooks {
 		// DB updates
 		// For now, there's just a single SQL file for all DB types.
 		// if ( $updater->getDB()->getType() == 'mysql' ) {
-			$updater->addExtensionUpdate( array( 'addTable', 'watch_tracking_user', __DIR__ . '/WatchAnalytics.sql', true ) );
+			$updater->addExtensionUpdate( [ 'addTable', 'watch_tracking_user', __DIR__ . '/WatchAnalytics.sql', true ] );
 		// }
 
 		return true;

--- a/specials/SpecialClearPendingReviews.php
+++ b/specials/SpecialClearPendingReviews.php
@@ -103,7 +103,6 @@ class SpecialClearPendingReviews extends SpecialPage {
 	 * @param bool $clearPages
 	 * @return $results
 	 */
-
 	public static function doSearchQuery( $data, $clearPages ) {
 		$dbw = wfGetDB( DB_REPLICA );
 		$category = preg_replace( '/\s+/', '_', $data['category'] );
@@ -152,7 +151,6 @@ class SpecialClearPendingReviews extends SpecialPage {
 	 * @param object $form
 	 * @return Status
 	 */
-
 	public function trySubmit( $data, $form ) {
 		$request = $this->getRequest();
 		$output = $this->getOutput();

--- a/specials/SpecialClearPendingReviews.php
+++ b/specials/SpecialClearPendingReviews.php
@@ -22,7 +22,7 @@ class SpecialClearPendingReviews extends SpecialPage {
 		$wgOut->addModules( 'ext.watchanalytics.clearpendingreviews.scripts' );
 		$output = $this->getOutput();
 
-		//Defines input form
+		// Defines input form
 		$formDescriptor = [
 				'start' => [
 					'section' => 'section1',
@@ -37,7 +37,7 @@ class SpecialClearPendingReviews extends SpecialPage {
 					'type' => 'text',
 					'required' => 'true',
 					'validation-callback' => [ $this, 'validateTime' ],
-					'help' => '<b>Current time:</b> '.date('YmdHi').'00',
+					'help' => '<b>Current time:</b> ' . date( 'YmdHi' ) . '00',
 				],
 				'category' => [
 					'section' => 'section2',
@@ -58,7 +58,6 @@ class SpecialClearPendingReviews extends SpecialPage {
 			$form->setSubmitName( 'preview' );
 			$form->setSubmitCallback( [ $this, 'trySubmit' ] );
 			$form->show();
-
 	}
 
 	public function validateTime( $dateField, $allData ) {
@@ -66,12 +65,12 @@ class SpecialClearPendingReviews extends SpecialPage {
 			return wfMessage( 'clearpendingreviews-date-invalid' )->inContentLanguage();
 		}
 
-		//Validates start time is before end time
+		// Validates start time is before end time
 		if ( $allData['start'] > $allData['end'] ) {
 			return wfMessage( 'clearpendingreviews-date-order-invalid' )->inContentLanguage();
 		}
 
-		//Verifys input format is ISO
+		// Verifys input format is ISO
 		$dateTime = DateTime::createFromFormat( 'YmdHis', $dateField );
 		if ( $dateTime ) {
 				return $dateTime->format( 'YmdHis' ) === $dateField;
@@ -83,14 +82,14 @@ class SpecialClearPendingReviews extends SpecialPage {
 	public function validateCategory( $categoryField, $allData ) {
 		$bad_cat_name = false;
 
-		//Validates either Category or Title field is used
-		if ( empty( $categoryField ) && empty ( $allData['page'] ) ) {
+		// Validates either Category or Title field is used
+		if ( empty( $categoryField ) && empty( $allData['page'] ) ) {
 			return wfMessage( 'clearpendingreviews-missing-date-category' )->inContentLanguage();
 		}
-		if ( empty ( $categoryField ) ) {
+		if ( empty( $categoryField ) ) {
 			return true;
 		} else {
-			//Verifys category exists in wiki
+			// Verifys category exists in wiki
 			$category_title = Title::makeTitleSafe( NS_CATEGORY, $categoryField );
 			if ( !$category_title->exists() ) {
 				return wfMessage( 'clearpendingreviews-category-invalid' )->inContentLanguage();
@@ -100,47 +99,47 @@ class SpecialClearPendingReviews extends SpecialPage {
 	}
 
 	/**
-	* @param array $data
-	* @param bool $clearPages
-	* @return $results
-	*/
+	 * @param array $data
+	 * @param bool $clearPages
+	 * @return $results
+	 */
 
 	public static function doSearchQuery( $data, $clearPages ) {
 		$dbw = wfGetDB( DB_REPLICA );
-		$category = preg_replace('/\s+/', '_', $data['category']);
-		$page = preg_replace('/\s+/', '_', $data['page']);
-		$start = preg_replace('/\s+/', '', $data['start']);
-		$end = preg_replace('/\s+/', '', $data['end']);
+		$category = preg_replace( '/\s+/', '_', $data['category'] );
+		$page = preg_replace( '/\s+/', '_', $data['page'] );
+		$start = preg_replace( '/\s+/', '', $data['start'] );
+		$end = preg_replace( '/\s+/', '', $data['end'] );
 		$conditions = '';
 
-		if ($category) {
+		if ( $category ) {
 			$conditions .= "c.cl_to='$category' AND ";
 		}
-		if ($page) {
+		if ( $page ) {
 			$conditions .= "w.wl_title LIKE '$page%' AND ";
 		}
 
-		$tables = array( 'w' => 'watchlist', 'p' => 'page', 'c' => 'categorylinks' );
-		$vars = array( 'w.*' );
+		$tables = [ 'w' => 'watchlist', 'p' => 'page', 'c' => 'categorylinks' ];
+		$vars = [ 'w.*' ];
 		$conditions .= "w.wl_notificationtimestamp IS NOT NULL AND w.wl_notificationtimestamp < $end AND w.wl_notificationtimestamp > $start";
-		$join_conds = array(
-			'p' => array(
+		$join_conds = [
+			'p' => [
 				'LEFT JOIN', 'w.wl_title=p.page_title'
-			),
-			'c' => array(
+			],
+			'c' => [
 				'LEFT JOIN', 'c.cl_from=p.page_id'
-			)
-		);
+			]
+		];
 
 		$results = $dbw->select( $tables, $vars, $conditions, __METHOD__, 'DISTINCT', $join_conds );
 
-		if ( $clearPages == True ) {
+		if ( $clearPages == true ) {
 			$dbw = wfGetDB( DB_MASTER );
 
-			foreach ($results as $result ) {
-				$values = array('wl_notificationtimestamp' => null );
-				$conds = array( 'wl_id' => $result->wl_id );
-				$options = array();
+			foreach ( $results as $result ) {
+				$values = [ 'wl_notificationtimestamp' => null ];
+				$conds = [ 'wl_id' => $result->wl_id ];
+				$options = [];
 				$dbw->update( 'watchlist', $values, $conds, __METHOD__, $options );
 			}
 		}
@@ -149,40 +148,40 @@ class SpecialClearPendingReviews extends SpecialPage {
 	}
 
 	/**
-	* @param array $data
-	* @param object $form
-	* @return Status
-	*/
+	 * @param array $data
+	 * @param object $form
+	 * @return Status
+	 */
 
 	public function trySubmit( $data, $form ) {
 		$request = $this->getRequest();
 		$output = $this->getOutput();
 		$this->setHeaders();
 
-		if (isset($_POST['clearpages'])) {
-			//Clears pending reviews
-			$results = $this->doSearchQuery( $data, True );
+		if ( isset( $_POST['clearpages'] ) ) {
+			// Clears pending reviews
+			$results = $this->doSearchQuery( $data, true );
 
-			//Count how many pages were cleared
+			// Count how many pages were cleared
 			$pageCount = 0;
 			foreach ( $results as $result ) {
 				$pageCount = $pageCount + 1;
 			}
 
-			//Log when pages are cleared in Special:Log
+			// Log when pages are cleared in Special:Log
 			$logEntry = new ManualLogEntry( 'pendingreviews', 'clearreivews' );
 			$logEntry->setPerformer( $this->getUser() );
 			$logEntry->setTarget( $this->getPageTitle() );
 			$logEntry->setParameters( [
-				'4::paramname' => '('.$pageCount.')',
-				'5::paramname' => '('.$data['category'].')',
-				'6::paramname' => '('.$data['page'].')',
+				'4::paramname' => '(' . $pageCount . ')',
+				'5::paramname' => '(' . $data['category'] . ')',
+				'6::paramname' => '(' . $data['page'] . ')',
 				] );
 			$logid = $logEntry->insert();
 			$logEntry->publish( $logid );
-			Hooks::run( 'PendingReviewsCleared', [&$data, &$results, &$pageCount] );
+			Hooks::run( 'PendingReviewsCleared', [ &$data, &$results, &$pageCount ] );
 
-			//Create link back to Special:ClearPendingReviews
+			// Create link back to Special:ClearPendingReviews
 			$pageLinkHtml = Linker::link( $this->getPageTitle() );
 			$output->addHTML( "<b>" );
 			$output->addHTML( wfMessage( 'clearpendingreviews-success' )->numParams( $pageCount )->plain() );
@@ -191,36 +190,36 @@ class SpecialClearPendingReviews extends SpecialPage {
 			$output->addHTML( wfMessage( 'clearpendingreviews-success-return' ) );
 			$output->addHTML( $pageLinkHtml );
 
-			//Don't reload the form after clearing pages.
+			// Don't reload the form after clearing pages.
 			return true;
 
 		} else {
-			$results = $this->doSearchQuery( $data, False );
+			$results = $this->doSearchQuery( $data, false );
 			$table = '';
 			$table .= "<table class='wikitable' style='width:100%'>";
 			$table .= "<tr>";
 			$table .= "<td style='vertical-align:top;'>";
-			$table .= "<h3>".wfMessage( 'clearpendingreviews-pages-cleared' )."</h3>";
+			$table .= "<h3>" . wfMessage( 'clearpendingreviews-pages-cleared' ) . "</h3>";
 			$table .= "<ul>";
-			$impactedPages = array();
-			foreach ($results as $result) {
+			$impactedPages = [];
+			foreach ( $results as $result ) {
 				$page = Title::makeTitle( $result->wl_namespace, $result->wl_title );
 				$pageLinkHtml = Linker::link( $page );
 				$impactedPages[] = $pageLinkHtml;
 			}
 
 			$impactedPages = array_unique( $impactedPages );
-			foreach ($impactedPages as $impactedPage ) {
-				$table .= "<li>".$impactedPage."</li>";
+			foreach ( $impactedPages as $impactedPage ) {
+				$table .= "<li>" . $impactedPage . "</li>";
 			}
 
 			$table .= "</ul>";
 			$table .= "</td>";
 			$table .= "<td style='vertical-align:top;'>";
-			$table .= "<h3>".wfMessage( 'clearpendingreviews-people-impacted' )."</h3>";
+			$table .= "<h3>" . wfMessage( 'clearpendingreviews-people-impacted' ) . "</h3>";
 			$table .= "<ul>";
-			$impactedUsers = array();
-			foreach ($results as $result ) {
+			$impactedUsers = [];
+			foreach ( $results as $result ) {
 				$user = User::newFromId( $result->wl_user );
 				$userTitleObj = $user->getUserPage();
 				$userLinkHtml = Linker::link( $userTitleObj );
@@ -228,8 +227,8 @@ class SpecialClearPendingReviews extends SpecialPage {
 			}
 
 			$impactedUsers = array_unique( $impactedUsers );
-			foreach ($impactedUsers as $impactedUser ) {
-				$table .= "<li>".$impactedUser."</li>";
+			foreach ( $impactedUsers as $impactedUser ) {
+				$table .= "<li>" . $impactedUser . "</li>";
 			}
 
 			$table .= "</ul>";
@@ -240,10 +239,10 @@ class SpecialClearPendingReviews extends SpecialPage {
 			$form->setSubmitText( 'Clear pages' );
 			$form->setSubmitName( 'clearpages' );
 			$form->setSubmitDestructive();
-			$form->setCancelTarget( $this->getPageTitle());
+			$form->setCancelTarget( $this->getPageTitle() );
 			$form->showCancel();
-			Hooks::run( 'PendingReviewsPreview', [&$data, &$results] );
-			//Display preview of pages to be cleared
+			Hooks::run( 'PendingReviewsPreview', [ &$data, &$results ] );
+			// Display preview of pages to be cleared
 			$form->setPostText( $table );
 
 			return false;

--- a/specials/SpecialPageStatistics.php
+++ b/specials/SpecialPageStatistics.php
@@ -3,12 +3,6 @@
 class SpecialPageStatistics extends SpecialPage {
 
 	public $mMode;
-	// protected $header_links = array(
-	// 'watchanalytics-pages-specialpage' => '',
-	// 'watchanalytics-users-specialpage' => 'users',
-	// 'watchanalytics-wikihistory-specialpage'  => 'wikihistory',
-	// 'watchanalytics-watch-forcegraph-specialpage' => 'forcegraph',
-	// );
 
 	public function __construct() {
 		parent::__construct(

--- a/specials/SpecialPageStatistics.php
+++ b/specials/SpecialPageStatistics.php
@@ -4,12 +4,11 @@ class SpecialPageStatistics extends SpecialPage {
 
 	public $mMode;
 	// protected $header_links = array(
-	// 	'watchanalytics-pages-specialpage' => '',
-	// 	'watchanalytics-users-specialpage' => 'users',
-	// 	'watchanalytics-wikihistory-specialpage'  => 'wikihistory',
-	// 	'watchanalytics-watch-forcegraph-specialpage' => 'forcegraph',
+	// 'watchanalytics-pages-specialpage' => '',
+	// 'watchanalytics-users-specialpage' => 'users',
+	// 'watchanalytics-wikihistory-specialpage'  => 'wikihistory',
+	// 'watchanalytics-watch-forcegraph-specialpage' => 'forcegraph',
 	// );
-
 
 	public function __construct() {
 		parent::__construct(
@@ -32,13 +31,13 @@ class SpecialPageStatistics extends SpecialPage {
 		// @todo: probably don't need filters, but may want to show stats just
 		// from a certain group of users
 		// $filters = array(
-		// 	'groupfilter'    => $wgRequest->getVal( 'groupfilter', '' ),
-		// 	'categoryfilter' => $wgRequest->getVal( 'categoryfilter', '' ),
+		// 'groupfilter'    => $wgRequest->getVal( 'groupfilter', '' ),
+		// 'categoryfilter' => $wgRequest->getVal( 'categoryfilter', '' ),
 		// );
 		// foreach( $filters as &$filter ) {
-		// 	if ( $filter === '' ) {
-		// 		$filter = false;
-		// 	}
+		// if ( $filter === '' ) {
+		// $filter = false;
+		// }
 		// }
 
 		// @todo: delete if multiple views not needed (thus, not requiring header call here)
@@ -48,28 +47,25 @@ class SpecialPageStatistics extends SpecialPage {
 			if ( $unReviewTimestamp ) {
 				$rh = new ReviewHandler( $wgUser, $this->mTitle );
 				$rh->resetNotificationTimestamp( $unReviewTimestamp );
-				$wgOut->addModuleStyles( array( 'ext.watchanalytics.reviewhandler.styles' ) );
+				$wgOut->addModuleStyles( [ 'ext.watchanalytics.reviewhandler.styles' ] );
 				$wgOut->addHTML( $this->unReviewMessage() );
 			}
-
 
 			$wgOut->addHTML( $this->getPageHeader() );
 			$this->renderPageStats();
 		}
-		else if ( $requestedPage ) {
+		elseif ( $requestedPage ) {
 			// @todo FIXME: internationalize
 			$wgOut->addHTML( "<p>\"$requestedPage\" is either not a page or is not watchable</p>" );
 		}
 		else {
 			$wgOut->addHTML( "<p>No page requested</p>" );
 		}
-
 	}
 
 	public function getPageHeader() {
 		global $wgOut;
-		$wgOut->addModuleStyles( array( 'ext.watchanalytics.pagescores.styles' ) );
-
+		$wgOut->addModuleStyles( [ 'ext.watchanalytics.pagescores.styles' ] );
 
 		$pageScore = new PageScore( $this->mTitle );
 		// $out->addScript( $pageScore->getPageScoreTemplate() );
@@ -105,28 +101,25 @@ class SpecialPageStatistics extends SpecialPage {
 				<td>The number of people who have reviewed this page.</td>
 			</tr>
 			</table>";
-
 	}
 
-	public function renderPageStats () {
-
+	public function renderPageStats() {
 		global $wgOut;
 
 		// @todo FIXME: internationalization
 		$wgOut->setPageTitle( 'Page Statistics: ' . $this->mTitle->getPrefixedText() );
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$html = '';
 		// Load the module for the D3.js force directed graph
 		// $wgOut->addModules( 'ext.watchanalytics.forcegraph.scripts' );
 		// Load the styles for the D3.js force directed graph
 		// $wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph.styles' );
 
-
 		// SELECT
-		// 	rev.rev_user,
-		// 	rev.rev_user_text,
-		// 	COUNT( * ) AS num_revisions
+		// rev.rev_user,
+		// rev.rev_user_text,
+		// COUNT( * ) AS num_revisions
 		// FROM revision AS rev
 		// LEFT JOIN page AS p ON p.page_id = rev.rev_page
 		// WHERE p.page_title = "US_EVA_29_(US_EVA_IDA1_Cables)" AND p.page_namespace = 0
@@ -134,38 +127,36 @@ class SpecialPageStatistics extends SpecialPage {
 		// ORDER BY num_revisions DESC
 
 		#
-		#	Page editors query
+		# Page editors query
 		#
 		$res = $dbr->select(
-			array(
+			[
 				'rev' => 'revision',
 				'p' => 'page',
-			),
-			array(
+			],
+			[
 				'rev.rev_user',
 				'rev.rev_user_text',
 				'COUNT( * ) AS num_revisions',
-			),
-			array(
+			],
+			[
 				'p.page_title' => $this->mTitle->getDBkey(),
 				'p.page_namespace' => $this->mTitle->getNamespace(),
-			),
+			],
 			__METHOD__,
-			array(
+			[
 				'GROUP BY' => 'rev.rev_user',
 				'ORDER BY' => 'num_revisions DESC',
-			),
-			array(
-				'p' => array(
+			],
+			[
+				'p' => [
 					'LEFT JOIN', 'p.page_id = rev.rev_page'
-				),
-			)
+				],
+			]
 		);
 
-
-
 		#
-		#	Page editors
+		# Page editors
 		#
 		$html .= Xml::element( 'h2', null, wfMessage( 'watchanalytics-pagestats-editors-list-title' )->text() );
 		$html .= Xml::openElement( "ul" );
@@ -185,37 +176,34 @@ class SpecialPageStatistics extends SpecialPage {
 		}
 		$html .= Xml::closeElement( "ul" );
 
-
 		#
-		#	Watchers query
+		# Watchers query
 		#
 		$res = $dbr->select(
-			array(
+			[
 				'w' => 'watchlist',
 				'u' => 'user',
-			),
-			array(
+			],
+			[
 				'wl_user',
 				'u.user_name',
 				'wl_notificationtimestamp',
-			),
-			array(
+			],
+			[
 				'wl_title' => $this->mTitle->getDBkey(),
 				'wl_namespace' => $this->mTitle->getNamespace(),
-			),
+			],
 			__METHOD__,
 			null, // no limits, order by, etc
-			array(
-				'u' => array(
+			[
+				'u' => [
 					'LEFT JOIN', 'u.user_id = w.wl_user'
-				),
-			)
+				],
+			]
 		);
 
-
-
 		#
-		#	Page watchers
+		# Page watchers
 		#
 		$html .= Xml::element( 'h2', null, wfMessage( 'watchanalytics-pagestats-watchers-title' )->text() );
 		$html .= Xml::openElement( "ul" );
@@ -241,29 +229,20 @@ class SpecialPageStatistics extends SpecialPage {
 		}
 		$html .= Xml::closeElement( "ul" );
 
-
-
 		$wgOut->addHTML( $html );
 
 		$this->pageChart();
-
 	}
 
-	public function unReviewMessage () {
-
+	public function unReviewMessage() {
 		// FIXME: Original self: this shouldn't use the same CSS ID.
-		//        Newer self: Why not?
-		return
-			"<div id='watch-analytics-review-handler'><p>" .
+		// Newer self: Why not?
+		return "<div id='watch-analytics-review-handler'><p>" .
 				wfMessage( 'watchanalytics-unreview-complete' )->parse() .
 			"</p></div>";
-
 	}
 
-
-
-	public function pageChart () {
-
+	public function pageChart() {
 		global $wgOut;
 		$wgOut->addModules( 'ext.watchanalytics.charts' );
 
@@ -273,26 +252,26 @@ class SpecialPageStatistics extends SpecialPage {
 		// $dateRangeStart = new MWTimestamp( date( 'YmdHis', strtotime( '2 weeks ago' ) ) );
 		// $dateRangeStart = $dateRangeStart->format('YmdHis');
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$res = $dbr->select(
-			array( 'wtp' => 'watch_tracking_page' ),
-			array(
+			[ 'wtp' => 'watch_tracking_page' ],
+			[
 				"DATE_FORMAT( wtp.tracking_timestamp, '%Y-%m-%d %H:%i:%s' ) AS timestamp",
 				"wtp.num_reviewed AS num_reviewed",
-			),
-			array(
+			],
+			[
 				'page_id' => $this->mTitle->getArticleID(),
 				// 'tracking_timestamp > ' . $dateRangeStart
-			),
+			],
 			__METHOD__,
-			array(
+			[
 				"ORDER BY" => "wtp.tracking_timestamp DESC",
 				"LIMIT" => "200", // MOST RECENT 100 changes
-			),
+			],
 			null // join conditions
 		);
 
-		$data = array();
+		$data = [];
 		while ( $row = $dbr->fetchObject( $res ) ) {
 			$data[ $row->timestamp ] = $row->num_reviewed;
 		}
@@ -302,7 +281,5 @@ class SpecialPageStatistics extends SpecialPage {
 
 		$html .= "<script type='text/template-json' id='ext-watchanalytics-page-stats-data'>" . json_encode( $data ) . "</script>";
 		$wgOut->addHTML( $html );
-
 	}
 }
-

--- a/specials/SpecialPageStatistics.php
+++ b/specials/SpecialPageStatistics.php
@@ -53,12 +53,10 @@ class SpecialPageStatistics extends SpecialPage {
 
 			$wgOut->addHTML( $this->getPageHeader() );
 			$this->renderPageStats();
-		}
-		elseif ( $requestedPage ) {
+		} elseif ( $requestedPage ) {
 			// @todo FIXME: internationalize
 			$wgOut->addHTML( "<p>\"$requestedPage\" is either not a page or is not watchable</p>" );
-		}
-		else {
+		} else {
 			$wgOut->addHTML( "<p>No page requested</p>" );
 		}
 	}
@@ -213,8 +211,7 @@ class SpecialPageStatistics extends SpecialPage {
 
 			if ( is_null( $row->wl_notificationtimestamp ) ) {
 				$watcherMsg = 'watchanalytics-pagestats-watchers-list-item-reviewed';
-			}
-			else {
+			} else {
 				$watcherMsg = 'watchanalytics-pagestats-watchers-list-item-unreviewed';
 			}
 

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -194,14 +194,12 @@ class SpecialPendingReviews extends SpecialPage {
 			$this->mUser = User::newFromName( $requestUser );
 			if ( $this->mUser->getId() === $viewingUser ) {
 				$this->mUserIsViewer = true;
-			}
-			else {
+			} else {
 				$this->mUserIsViewer = false;
 			}
 			$this->getOutput()->setPageTitle( wfMessage( 'pendingreviews-user-page', $this->mUser->getName() )->text() );
 
-		}
-		else {
+		} else {
 			$this->mUser = $viewingUser;
 		}
 
@@ -216,8 +214,7 @@ class SpecialPendingReviews extends SpecialPage {
 	public function setReviewLimit() {
 		if ( $this->getRequest()->getVal( 'limit' ) ) {
 			$this->reviewLimit = $this->getRequest()->getVal( 'limit' ); // FIXME: for consistency, shouldn't this be just "limit"
-		}
-		else {
+		} else {
 			$this->reviewLimit = 20;
 		}
 	}
@@ -230,8 +227,7 @@ class SpecialPendingReviews extends SpecialPage {
 	public function setReviewOffset() {
 		if ( $this->getRequest()->getVal( 'offset' ) ) {
 			$this->reviewOffset = $this->getRequest()->getVal( 'offset' );
-		}
-		else {
+		} else {
 			$this->reviewOffset = 0;
 		}
 	}
@@ -271,8 +267,7 @@ class SpecialPendingReviews extends SpecialPage {
 
 		if ( $item->title->isRedirect() ) {
 			$reviewButton = $this->getAcceptRedirectButton( $item );
-		}
-		else {
+		} else {
 			$reviewButton = $this->getReviewButton( $item );
 		}
 
@@ -299,8 +294,7 @@ class SpecialPendingReviews extends SpecialPage {
 			if ( $item->deletionLog[$i]->log_type == 'move' ) {
 				$pageWasMoved = true;
 				break;
-			}
-			elseif ( $item->deletionLog[$i]->log_type == 'delete' ) {
+			} elseif ( $item->deletionLog[$i]->log_type == 'delete' ) {
 				$pageWasMoved = false;
 				break;
 			}
@@ -311,8 +305,7 @@ class SpecialPendingReviews extends SpecialPage {
 		if ( $pageWasMoved ) {
 			$acceptDeletionButton = $this->getAcceptMoveWithoutRedirectButton( $item->deletedTitle, $item->deletedNS );
 			$displayMessage = 'pendingreviews-page-moved-no-redirect';
-		}
-		else {
+		} else {
 			$acceptDeletionButton = $this->getMarkDeleteReviewedButton( $item->deletedTitle, $item->deletedNS );
 			$displayMessage = 'pendingreviews-page-deleted';
 		}
@@ -344,11 +337,9 @@ class SpecialPendingReviews extends SpecialPage {
 
 		if ( $item->numReviewers > $GLOBALS['egPendingReviewsOrangePagesThreshold'] ) {
 			$reviewCriticality = 'green'; // page is "green" because it has lots of reviewers
-		}
-		elseif ( $item->numReviewers > $GLOBALS['egPendingReviewsRedPagesThreshold'] ) {
+		} elseif ( $item->numReviewers > $GLOBALS['egPendingReviewsRedPagesThreshold'] ) {
 			$reviewCriticality = 'orange';
-		}
-		else {
+		} else {
 			$reviewCriticality = 'red'; // page is red because it has very few reviewers
 		}
 		$reviewCriticalityClass = 'pendingreviews-criticality-' . $reviewCriticality;
@@ -374,8 +365,7 @@ class SpecialPendingReviews extends SpecialPage {
 			// returns essentially the negative-oneth revision...the one before
 			// the wl_notificationtimestamp revision...or null/false if none exists?
 			$mostRecentReviewed = Revision::newFromRow( $item->newRevisions[0] )->getPrevious();
-		}
-		else {
+		} else {
 			$mostRecentReviewed = false; // no previous revision, the user has not reviewed the first!
 		}
 
@@ -393,8 +383,7 @@ class SpecialPendingReviews extends SpecialPage {
 					count( $item->newRevisions )
 				)->text()
 			);
-		}
-		else {
+		} else {
 
 			$latest = Revision::newFromTitle( $item->title );
 			$diffURL = $item->title->getLocalURL( [ 'oldid' => $latest->getId() ] );
@@ -530,8 +519,7 @@ class SpecialPendingReviews extends SpecialPage {
 
 		if ( $userTalk->exists() ) {
 			$talkQueryString = [];
-		}
-		else {
+		} else {
 			$talkQueryString = [ 'action' => 'edit' ];
 		}
 
@@ -669,8 +657,7 @@ class SpecialPendingReviews extends SpecialPage {
 
 			if ( $revTs > $logTs ) {
 				$combinedArray[] = array_shift( $log );
-			}
-			else {
+			} else {
 				$combinedArray[] = array_shift( $revisions );
 			}
 
@@ -761,8 +748,7 @@ class SpecialPendingReviews extends SpecialPage {
 			if ( isset( $change->log_timestamp ) ) {
 				$changeTs = $change->log_timestamp;
 				$changeText = $this->getLogChangeMessage( $change );
-			}
-			else {
+			} else {
 				$rev = Revision::newFromRow( $change );
 				$changeTs = $change->rev_timestamp;
 				$userPage = Title::makeTitle( NS_USER, $change->rev_user_text )->getFullText();
@@ -771,8 +757,7 @@ class SpecialPendingReviews extends SpecialPage {
 				if ( $comment ) {
 					$comment = '<span class="comment">' . Linker::formatComment( $comment ) . '</span>';
 					$changeText = ' ' . wfMessage( 'pendingreviews-with-comment', [ $userPage ] )->parse() . ' ' . $comment;
-				}
-				else {
+				} else {
 					$changeText = ' ' . wfMessage( 'pendingreviews-edited-by', $userPage )->parse();
 				}
 			}

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -135,9 +135,9 @@ class SpecialPendingReviews extends SpecialPage {
 			// been deleted)
 			if ( $item->title ) {
 				$html .= $this->getStandardChangeRow( $item, $rowCount );
-			}
+
 			// page has been deleted (or moved w/o a redirect)
-			else {
+			} else {
 				$html .= $this->getDeletedPageRow( $item, $rowCount );
 			}
 
@@ -728,10 +728,8 @@ class SpecialPendingReviews extends SpecialPage {
 
 			return wfMessage( $messages[ $logEntry->log_type ][ $logEntry->log_action ], $messageParams );
 
-		}
-
 		// if no message exists for the log type and action, handling with "unknown change"
-		else {
+		} else {
 			return wfMessage( 'pendingreviews-log-unknown-change', $userPage );
 		}
 	}

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -160,6 +160,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 * Handles case where user clicked a link to clear a pending review
 	 * This will not display the pending reviews page.
 	 *
+	 * @param Title $clearNotifyTitle
 	 * @return bool
 	 */
 	public function handleClearNotification( $clearNotifyTitle ) {
@@ -344,9 +345,14 @@ class SpecialPendingReviews extends SpecialPage {
 		}
 		$reviewCriticalityClass = 'pendingreviews-criticality-' . $reviewCriticality;
 
-		$classAndAttr = "class='pendingreviews-row $rowClass $reviewCriticalityClass pendingreviews-row-$rowCount' pendingreviews-row-count='$rowCount'";
+		$classAndAttr = "class='pendingreviews-row $rowClass " .
+			"$reviewCriticalityClass pendingreviews-row-$rowCount' " .
+			"pendingreviews-row-count='$rowCount'";
 
-		$html = "<tr $classAndAttr><td class='pendingreviews-page-title pendingreviews-top-cell'>$displayTitle</td><td class='pendingreviews-review-links pendingreviews-bottom-cell pendingreviews-top-cell'>$buttonOne $buttonTwo</td></tr>";
+		$html = "<tr $classAndAttr><td class='pendingreviews-page-title pendingreviews-top-cell'>" .
+			"$displayTitle</td>" .
+			"<td class='pendingreviews-review-links pendingreviews-bottom-cell pendingreviews-top-cell'>" .
+			"$buttonOne $buttonTwo</td></tr>";
 
 		$html .= "<tr $classAndAttr><td colspan='2' class='pendingreviews-bottom-cell'>$changes</td></tr>";
 
@@ -504,10 +510,10 @@ class SpecialPendingReviews extends SpecialPage {
 	 * Creates a button bringing user to the talk page of the user who deleted
 	 * the page, allowing them to ask questions about why the page was deleted.
 	 *
-	 * @param $deletionLog
+	 * @param array $deletionLog
 	 * @return string HTML for button
 	 */
-	public function getDeleterTalkButton( $deletionLog ) {
+	public function getDeleterTalkButton( array $deletionLog ) {
 		if ( count( $deletionLog ) == 0 ) {
 			return '';
 		}
@@ -535,9 +541,10 @@ class SpecialPendingReviews extends SpecialPage {
 	/**
 	 * Creates simple header stating how many pending reviews the user has.
 	 *
+	 * @param User $user
 	 * @return string HTML for header
 	 */
-	public function getPageHeader( $user ) {
+	public function getPageHeader( User $user ) {
 		$userWatch = new UserWatchesQuery();
 		$watchStats = $userWatch->getUserWatchStats( $user );
 		$numPendingReviews = $watchStats['num_pending'];
@@ -633,12 +640,12 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @todo FIXME: documentation...why does this do what it does?
 	 * @todo FIXME: cleanup temporary code
 	 *
-	 * @param $log
-	 * @param $revisions
-	 * @param $title
+	 * @param array $log
+	 * @param array $revisions
+	 * @param Title $title
 	 * @return array
 	 */
-	protected function combineLogAndChanges( $log, $revisions, $title ) {
+	protected function combineLogAndChanges( array $log, array $revisions, Title $title ) {
 		// if ( $title->getNamespace() === NS_FILE ) {
 
 		// }

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -33,12 +33,11 @@
 class SpecialPendingReviews extends SpecialPage {
 
 	public $mMode;
-	protected $header_links = array(
+	protected $header_links = [
 		'watchanalytics-pages-specialpage' => '',
 		'watchanalytics-users-specialpage' => 'users',
 		'watchanalytics-wikihistory-specialpage'  => 'wikihistory',
-	);
-
+	];
 
 	/**
 	 * Constructor for Special Page.
@@ -163,8 +162,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return bool
 	 */
-	public function handleClearNotification ( $clearNotifyTitle ) {
-
+	public function handleClearNotification( $clearNotifyTitle ) {
 		PendingReview::clearByUserAndTitle( $this->getUser(), $clearNotifyTitle );
 
 		$this->getOutput()->addHTML(
@@ -172,15 +170,14 @@ class SpecialPendingReviews extends SpecialPage {
 				'pendingreviews-clear-page-notification',
 				$clearNotifyTitle->getFullText(),
 				Xml::tags( 'a',
-					array(
+					[
 						'href' => $this->getTitle()->getLocalUrl(),
 						'style' => 'font-weight:bold;',
-					),
+					],
 					$this->getTitle()
 				)
 			)->text()
 		);
-
 	}
 
 	/**
@@ -188,8 +185,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return bool
 	 */
-	public function setPendingReviewsUser () {
-
+	public function setPendingReviewsUser() {
 		$viewingUser = $this->getUser();
 
 		// Check if a user has been specified.
@@ -217,7 +213,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return null
 	 */
-	public function setReviewLimit () {
+	public function setReviewLimit() {
 		if ( $this->getRequest()->getVal( 'limit' ) ) {
 			$this->reviewLimit = $this->getRequest()->getVal( 'limit' ); // FIXME: for consistency, shouldn't this be just "limit"
 		}
@@ -231,7 +227,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return null
 	 */
-	public function setReviewOffset () {
+	public function setReviewOffset() {
 		if ( $this->getRequest()->getVal( 'offset' ) ) {
 			$this->reviewOffset = $this->getRequest()->getVal( 'offset' );
 		}
@@ -246,8 +242,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return Title|false
 	 */
-	public function getClearNotificationTitle () {
-
+	public function getClearNotificationTitle() {
 		$clearNotifyTitle = $this->getRequest()->getVal( 'clearNotificationTitle' );
 
 		if ( ! $clearNotifyTitle ) {
@@ -263,7 +258,6 @@ class SpecialPendingReviews extends SpecialPage {
 		return $title;
 	}
 
-
 	/**
 	 * Generates row for a particular page in PendingReviews.
 	 *
@@ -271,8 +265,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param int $rowCount used to determine if the row is odd or even
 	 * @return string HTML for row
 	 */
-	public function getStandardChangeRow ( PendingReview $item, $rowCount ) {
-
+	public function getStandardChangeRow( PendingReview $item, $rowCount ) {
 		$combinedList = $this->combineLogAndChanges( $item->log, $item->newRevisions, $item->title );
 		$changes = $this->getPendingReviewChangesList( $combinedList );
 
@@ -288,7 +281,6 @@ class SpecialPendingReviews extends SpecialPage {
 		$displayTitle = '<strong>' . $item->title->getFullText() . '</strong>';
 
 		return $this->getRowHTML( $item, $rowCount, $displayTitle, $reviewButton, $historyButton, $changes );
-
 	}
 
 	/**
@@ -300,8 +292,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param int $rowCount used to determine if the row is odd or even
 	 * @return string HTML for row
 	 */
-	public function getDeletedPageRow ( PendingReview $item, $rowCount ) {
-
+	public function getDeletedPageRow( PendingReview $item, $rowCount ) {
 		$pageWasMoved = false;
 		$deletionLogLength = count( $item->deletionLog );
 		for ( $i = $deletionLogLength - 1; $i >= 0; $i-- ) {
@@ -309,7 +300,7 @@ class SpecialPendingReviews extends SpecialPage {
 				$pageWasMoved = true;
 				break;
 			}
-			else if ( $item->deletionLog[$i]->log_type == 'delete' ) {
+			elseif ( $item->deletionLog[$i]->log_type == 'delete' ) {
 				$pageWasMoved = false;
 				break;
 			}
@@ -347,15 +338,14 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param string $changes
 	 * @return string HTML for pending review of a given page
 	 */
-	public function getRowHTML ( PendingReview $item, $rowCount, $displayTitle, $buttonOne, $buttonTwo, $changes ) {
-
+	public function getRowHTML( PendingReview $item, $rowCount, $displayTitle, $buttonOne, $buttonTwo, $changes ) {
 		// FIXME: wow this is ugly
 		$rowClass = ( $rowCount % 2 === 0 ) ? 'pendingreviews-even-row' : 'pendingreviews-odd-row';
 
 		if ( $item->numReviewers > $GLOBALS['egPendingReviewsOrangePagesThreshold'] ) {
 			$reviewCriticality = 'green'; // page is "green" because it has lots of reviewers
 		}
-		else if ( $item->numReviewers > $GLOBALS['egPendingReviewsRedPagesThreshold'] ) {
+		elseif ( $item->numReviewers > $GLOBALS['egPendingReviewsRedPagesThreshold'] ) {
 			$reviewCriticality = 'orange';
 		}
 		else {
@@ -378,8 +368,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param PendingReview $item
 	 * @return string HTML for button
 	 */
-	public function getReviewButton ( $item ) {
-
+	public function getReviewButton( $item ) {
 		if ( count( $item->newRevisions ) > 0 ) {
 
 			// returns essentially the negative-oneth revision...the one before
@@ -392,13 +381,13 @@ class SpecialPendingReviews extends SpecialPage {
 
 		if ( $mostRecentReviewed ) {
 
-			$diffURL = $item->title->getLocalURL( array(
+			$diffURL = $item->title->getLocalURL( [
 				'diff' => '',
 				'oldid' => $mostRecentReviewed->getId()
-			) );
+			] );
 
 			$diffLink = Xml::element( 'a',
-				array( 'href' => $diffURL, 'class' => 'pendingreviews-green-button', 'target' => "_blank" ),
+				[ 'href' => $diffURL, 'class' => 'pendingreviews-green-button', 'target' => "_blank" ],
 				wfMessage(
 					'watchanalytics-pendingreviews-diff-revisions',
 					count( $item->newRevisions )
@@ -408,10 +397,10 @@ class SpecialPendingReviews extends SpecialPage {
 		else {
 
 			$latest = Revision::newFromTitle( $item->title );
-			$diffURL = $item->title->getLocalURL( array( 'oldid' => $latest->getId() ) );
+			$diffURL = $item->title->getLocalURL( [ 'oldid' => $latest->getId() ] );
 
 			$diffLink = Xml::element( 'a',
-				array( 'href' => $diffURL, 'class' => 'pendingreviews-green-button', 'target' => "_blank" ),
+				[ 'href' => $diffURL, 'class' => 'pendingreviews-green-button', 'target' => "_blank" ],
 				$this->msg( 'watchanalytics-pendingreviews-users-first-view' )->text()
 			);
 
@@ -426,17 +415,16 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param PendingReview $item
 	 * @return string HTML for button
 	 */
-	public function getHistoryButton ( $item ) {
+	public function getHistoryButton( $item ) {
 		return Xml::element( 'a',
-			array(
-				'href' => $item->title->getLocalURL( array( 'action' => 'history' ) ),
+			[
+				'href' => $item->title->getLocalURL( [ 'action' => 'history' ] ),
 				'class' => 'pendingreviews-dark-blue-button',
 				'target' => "_blank"
-			),
+			],
 			wfMessage( 'watchanalytics-pendingreviews-history-link' )->text()
 		);
 	}
-
 
 	/**
 	 * Creates a button which marks a deleted or redirected page as "reviewed"
@@ -457,17 +445,17 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return string HTML for button
 	 */
-	public function getClearNotificationButton ( $titleText, $namespace, $buttonMsg, $buttonClass ) {
+	public function getClearNotificationButton( $titleText, $namespace, $buttonMsg, $buttonClass ) {
 		return Xml::element( 'a',
-			array(
-				'href' => $this->getTitle()->getLocalURL( array(
+			[
+				'href' => $this->getTitle()->getLocalURL( [
 					'clearNotificationTitle' => $titleText,
 					'clearNotificationNS' => $namespace,
-				) ),
+				] ),
 				'class' => $buttonClass,
 				'pending-namespace' => $namespace,
 				'pending-title' => $titleText,
-			),
+			],
 			wfMessage( $buttonMsg )->text()
 		);
 	}
@@ -481,7 +469,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return string HTML for button
 	 */
-	public function getMarkDeleteReviewedButton ( $titleText, $namespace ) {
+	public function getMarkDeleteReviewedButton( $titleText, $namespace ) {
 		return $this->getClearNotificationButton(
 			$titleText, $namespace, 'pendingreviews-accept-deletion',
 			'pendingreviews-red-button pendingreviews-accept-deletion'
@@ -499,7 +487,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return string HTML for button
 	 */
-	public function getAcceptMoveWithoutRedirectButton ( $titleText, $namespace ) {
+	public function getAcceptMoveWithoutRedirectButton( $titleText, $namespace ) {
 		return $this->getClearNotificationButton(
 			$titleText, $namespace, 'pendingreviews-accept-move-without-redirect',
 			'pendingreviews-orange-button pendingreviews-accept-deletion'
@@ -513,7 +501,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return string HTML for button
 	 */
-	public function getAcceptRedirectButton ( $item ) {
+	public function getAcceptRedirectButton( $item ) {
 		$titleText = $item->title->getDBkey();
 		$namespace = $item->title->getNamespace();
 
@@ -530,8 +518,7 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param $deletionLog
 	 * @return string HTML for button
 	 */
-	public function getDeleterTalkButton ( $deletionLog ) {
-
+	public function getDeleterTalkButton( $deletionLog ) {
 		if ( count( $deletionLog ) == 0 ) {
 			return '';
 		}
@@ -542,17 +529,17 @@ class SpecialPendingReviews extends SpecialPage {
 		$userTalk = $user->getTalkPage();
 
 		if ( $userTalk->exists() ) {
-			$talkQueryString = array();
+			$talkQueryString = [];
 		}
 		else {
-			$talkQueryString = array( 'action' => 'edit' );
+			$talkQueryString = [ 'action' => 'edit' ];
 		}
 
 		return Xml::element( 'a',
-			array(
+			[
 				'href' => $userTalk->getLocalURL( $talkQueryString ),
 				'class' => 'pendingreviews-dark-blue-button' // pendingreviews-delete-talk-button
-			),
+			],
 			wfMessage( 'pendingreviews-page-deleted-talk', $user->getUserPage()->getFullText() )->text()
 		);
 	}
@@ -580,12 +567,12 @@ class SpecialPendingReviews extends SpecialPage {
 		$html .= '</p>';
 
 		$nextReviewSet = $this->reviewOffset + $this->reviewLimit;
-		$prevReviewSet = max( array( 0, $this->reviewOffset - $this->reviewLimit ) );
+		$prevReviewSet = max( [ 0, $this->reviewOffset - $this->reviewLimit ] );
 		$currentURL = $this->getPageTitle()->getLocalUrl();
 
 		$viewingUser = '';
 		// if ( $this->mUser ) {
-		// 	$viewingUser = '&user='.$this->mUser;
+		// $viewingUser = '&user='.$this->mUser;
 		// }
 
 		$linkClass = "pendingreviews-nav-link";
@@ -602,19 +589,19 @@ class SpecialPendingReviews extends SpecialPage {
 
 		$html .= Xml::element(
 			'a',
-			array(
-				'href' => $currentURL.'?offset='.$prevReviewSet.$viewingUser,
+			[
+				'href' => $currentURL . '?offset=' . $prevReviewSet . $viewingUser,
 				'class' => $prevLinkClass,
-			),
+			],
 			wfMessage( 'watchanalytics-pendingreviews-prev-revisions' )->text()
 		);
 
 		$html .= Xml::element(
 			'a',
-			array(
-				'href' => $currentURL.'?offset='.$nextReviewSet.$viewingUser,
+			[
+				'href' => $currentURL . '?offset=' . $nextReviewSet . $viewingUser,
 				'class' => $nextLinkClass,
-			),
+			],
 			wfMessage( 'watchanalytics-pendingreviews-next-revisions' )->text()
 		);
 
@@ -626,10 +613,9 @@ class SpecialPendingReviews extends SpecialPage {
 	 *
 	 * @return string HTML for legend (table)
 	 */
-	public function getPendingReviewsLegend () {
-
+	public function getPendingReviewsLegend() {
 		$redMaxReviewers = $GLOBALS['egPendingReviewsRedPagesThreshold'] - 1;
-		$orangeMaxReviewers =  $GLOBALS['egPendingReviewsOrangePagesThreshold'] - 1;
+		$orangeMaxReviewers = $GLOBALS['egPendingReviewsOrangePagesThreshold'] - 1;
 
 		$redReviewersMsg = $this->msg(
 			'pendingreviews-reviewer-criticality-red',
@@ -651,7 +637,6 @@ class SpecialPendingReviews extends SpecialPage {
 			<tr class='pendingreviews-criticality-orange'><td>$orangeReviewersMsg</td></tr>
 			<tr class='pendingreviews-criticality-green'><td>$greenReviewersMsg</td></tr>
 		</table>";
-
 	}
 
 	/**
@@ -666,18 +651,16 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @return array
 	 */
 	protected function combineLogAndChanges( $log, $revisions, $title ) {
-
 		// if ( $title->getNamespace() === NS_FILE ) {
 
 		// }
-
 
 		// $log = array_reverse( $log );
 		// $revisions = array_reverse( $revisions );
 		$logI = 0;
 		$revI = 0;
 
-		$combinedArray = array();
+		$combinedArray = [];
 
 		while ( count( $log ) > 0 && count( $revisions ) > 0 ) {
 
@@ -699,7 +682,6 @@ class SpecialPendingReviews extends SpecialPage {
 		$combinedArray = array_merge( $combinedArray, $revisions, $log );
 
 		return $combinedArray;
-
 	}
 
 	/**
@@ -710,44 +692,43 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param object $logEntry
 	 * @return Message HTML for button
 	 */
-	protected function getLogChangeMessage ( $logEntry ) {
-
+	protected function getLogChangeMessage( $logEntry ) {
 		// add pendingreviews-edited-by?
-		$messages = array(
-			'approval' => array(
+		$messages = [
+			'approval' => [
 				'approve'    => 'pendingreviews-log-approved',
 				'unapprove'  => 'pendingreviews-log-unapproved'
-			),
-			'delete' => array(
+			],
+			'delete' => [
 				'delete'     => 'pendingreviews-log-delete',
 				'restore'    => 'pendingreviews-log-restore',
-			),
-			'import' => array(
+			],
+			'import' => [
 				'upload'     => 'pendingreviews-log-import-upload',
-			),
-			'move' => array(
+			],
+			'move' => [
 				'move'       => 'pendingreviews-log-move',
 				'move_redir' => 'pendingreviews-log-move-redir',
-			),
-			'protect' => array(
+			],
+			'protect' => [
 				'protect'    => 'pendingreviews-log-protect',
 				'unprotect'  => 'pendingreviews-log-unprotect',
 				'modify'     => 'pendingreviews-log-modify-protect',
-			),
-			'upload' => array(
+			],
+			'upload' => [
 				'upload'     => 'pendingreviews-log-upload-new',
 				'overwrite'  => 'pendingreviews-log-upload-overwrite',
-			),
-		);
+			],
+		];
 
 		// get user page of user who created the log entry
-		$userPage = Title::makeTitle( NS_USER , $logEntry->log_user_text )->getFullText();
+		$userPage = Title::makeTitle( NS_USER, $logEntry->log_user_text )->getFullText();
 
 		// if a message exists for the particular log type, handle it as follows
 		if ( isset( $messages[ $logEntry->log_type ][ $logEntry->log_action ] ) ) {
 
 			// all messages will use the executing users user-page
-			$messageParams = array( $userPage );
+			$messageParams = [ $userPage ];
 
 			// if the log action is move or move_redir, the move target is in the message
 			if ( $logEntry->log_action == 'move' || $logEntry->log_action == 'move_redir' ) {
@@ -766,7 +747,6 @@ class SpecialPendingReviews extends SpecialPage {
 		else {
 			return wfMessage( 'pendingreviews-log-unknown-change', $userPage );
 		}
-
 	}
 
 	/**
@@ -775,8 +755,8 @@ class SpecialPendingReviews extends SpecialPage {
 	 * @param array $combinedList
 	 * @return string HTML
 	 */
-	public function getPendingReviewChangesList ( $combinedList ) {
-		$changes = array();
+	public function getPendingReviewChangesList( $combinedList ) {
+		$changes = [];
 		foreach ( $combinedList as $change ) {
 			if ( isset( $change->log_timestamp ) ) {
 				$changeTs = $change->log_timestamp;
@@ -785,20 +765,20 @@ class SpecialPendingReviews extends SpecialPage {
 			else {
 				$rev = Revision::newFromRow( $change );
 				$changeTs = $change->rev_timestamp;
-				$userPage = Title::makeTitle( NS_USER , $change->rev_user_text )->getFullText();
+				$userPage = Title::makeTitle( NS_USER, $change->rev_user_text )->getFullText();
 
 				$comment = $rev->getComment();
 				if ( $comment ) {
 					$comment = '<span class="comment">' . Linker::formatComment( $comment ) . '</span>';
-					$changeText = ' ' . wfMessage( 'pendingreviews-with-comment', array( $userPage ) )->parse() . ' ' . $comment;
+					$changeText = ' ' . wfMessage( 'pendingreviews-with-comment', [ $userPage ] )->parse() . ' ' . $comment;
 				}
 				else {
 					$changeText = ' ' . wfMessage( 'pendingreviews-edited-by', $userPage )->parse();
 				}
-			}
+	}
 
 			$changeTs = Xml::element( 'span',
-				array( 'class' => 'pendingreviews-changes-list-time' ),
+				[ 'class' => 'pendingreviews-changes-list-time' ],
 				( new MWTimestamp( $changeTs ) )->getHumanTimestamp()
 			) . ' ';
 

--- a/specials/SpecialPendingReviews.php
+++ b/specials/SpecialPendingReviews.php
@@ -775,7 +775,7 @@ class SpecialPendingReviews extends SpecialPage {
 				else {
 					$changeText = ' ' . wfMessage( 'pendingreviews-edited-by', $userPage )->parse();
 				}
-	}
+			}
 
 			$changeTs = Xml::element( 'span',
 				[ 'class' => 'pendingreviews-changes-list-time' ],

--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -161,7 +161,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 	}
 
 	public function createTablePager( $titleMsg, WatchAnalyticsTablePager $tablePager ) {
-		global $wgOut, $wgRequest;
+		global $wgOut;
 
 		$wgOut->setPageTitle( wfMessage( $titleMsg )->text() );
 
@@ -191,18 +191,6 @@ class SpecialWatchAnalytics extends SpecialPage {
 		$wgOut->addModules( 'ext.watchanalytics.forcegraph.scripts' );
 		// Load the styles for the D3.js force directed graph
 		$wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph.styles' );
-
-		// SELECT
-		// watchlist.wl_title AS title,
-		// watchlist.wl_notificationtimestamp AS notification,
-		// user.user_name AS user_name,
-		// user.user_real_name AS real_name
-		// FROM watchlist
-		// LEFT JOIN user ON user.user_id = watchlist.wl_user
-		// WHERE
-		// wl_namespace = 0
-		// AND user.user_name IN (\'Lwelsh\',\'Swray\',\'Balpert\',\'Ejmontal\',\'Cmavridi\', \'Sgeffert\', \'Smulhern\', \'Kgjohns1\', \'Bscheib\', \'Ssjohns5\')
-		// LIMIT 20000
 
 		$res = $dbr->select(
 			[

--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -3,13 +3,12 @@
 class SpecialWatchAnalytics extends SpecialPage {
 
 	public $mMode;
-	protected $header_links = array(
+	protected $header_links = [
 		'watchanalytics-pages-specialpage' => '',
 		'watchanalytics-users-specialpage' => 'users',
 		'watchanalytics-wikihistory-specialpage'  => 'wikihistory',
 		'watchanalytics-watch-forcegraph-specialpage' => 'forcegraph',
-	);
-
+	];
 
 	public function __construct() {
 		parent::__construct(
@@ -19,7 +18,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 		);
 	}
 
-	public function execute ( $parser = null ) {
+	public function execute( $parser = null ) {
 		global $wgRequest, $wgOut;
 
 		$this->setHeaders();
@@ -37,10 +36,10 @@ class SpecialWatchAnalytics extends SpecialPage {
 			$wgOut->addHTML( '<p>' . wfMessage( 'watchanalytics-all-wiki-stats-recorded' )->text() . '</p>' );
 		}
 
-		$filters = array(
+		$filters = [
 			'groupfilter'    => $wgRequest->getVal( 'groupfilter', '' ),
 			'categoryfilter' => $wgRequest->getVal( 'categoryfilter', '' ),
-		);
+		];
 		foreach ( $filters as &$filter ) {
 			if ( $filter === '' ) {
 				$filter = false;
@@ -50,50 +49,46 @@ class SpecialWatchAnalytics extends SpecialPage {
 		$wgOut->addHTML( $this->getPageHeader() );
 		if ( $this->mMode == 'users' ) {
 			$this->usersList( $filters );
-		}
-		else if ( $this->mMode == 'wikihistory' ) {
+		} elseif ( $this->mMode == 'wikihistory' ) {
 			$this->wikiHistory();
-		}
-		else if ( $this->mMode == 'forcegraph' ) {
+		} elseif ( $this->mMode == 'forcegraph' ) {
 			$this->forceGraph();
-		}
-		else {
+		} else {
 			$this->pagesList( $filters );
 		}
 	}
 
 	public function getPageHeader() {
-
 		// show the names of the four lists of pages, with the one
 		// corresponding to the current "mode" not being linked
 
 		// SELECT
-		// 	COUNT(*) AS watches,
-		// 	SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending,
-		// 	SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending
+		// COUNT(*) AS watches,
+		// SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending,
+		// SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending
 		// FROM watchlist
 		// INNER JOIN page ON page.page_namespace = watchlist.wl_namespace AND page.page_title = watchlist.wl_title;		$dbr = wfGetDB( DB_SLAVE );
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		// $res = $dbr->select(
-		// 	array(
-		// 		'w' => 'watchlist',
-		// 		'p' => 'page',
-		// 	),
-		// 	array(
-		// 		"COUNT(*) AS watches",
-		// 		"SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending",
-		// 		"SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending",
-		// 	),
-		// 	null, // conditions
-		// 	__METHOD__,
-		// 	array(), // options
-		// 	array(
-		// 		'page' => array(
-		// 			'INNER JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
-		// 		)
-		// 	)
+		// array(
+		// 'w' => 'watchlist',
+		// 'p' => 'page',
+		// ),
+		// array(
+		// "COUNT(*) AS watches",
+		// "SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending",
+		// "SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) * 100 / COUNT(*) AS percent_pending",
+		// ),
+		// null, // conditions
+		// __METHOD__,
+		// array(), // options
+		// array(
+		// 'page' => array(
+		// 'INNER JOIN', 'p.page_namespace=w.wl_namespace AND p.page_title=w.wl_title'
+		// )
+		// )
 		// );
 
 		$res = $dbr->query( '
@@ -107,11 +102,11 @@ class SpecialWatchAnalytics extends SpecialPage {
 
 		$allWikiData = $dbr->fetchRow( $res );
 
-		list( $watches, $pending, $percent ) = array(
+		list( $watches, $pending, $percent ) = [
 			$allWikiData['num_watches'],
 			$allWikiData['num_pending'],
 			$allWikiData['percent_pending']
-		);
+		];
 
 		$percent = round( $percent, 1 );
 		$stateOf = "<strong>The state of the Wiki: </strong>$watches watches of which $percent% ($pending) are pending";
@@ -124,12 +119,10 @@ class SpecialWatchAnalytics extends SpecialPage {
 		$header = '<strong>' . wfMessage( 'watchanalytics-view' )->text() . '</strong>';
 		$header .= Xml::tags( 'ul', null, $navLinks ) . "\n";
 
-		return $stateOf . Xml::tags( 'div', array( 'class' => 'special-watchanalytics-header' ), $header );
-
+		return $stateOf . Xml::tags( 'div', [ 'class' => 'special-watchanalytics-header' ], $header );
 	}
 
 	public function createHeaderLink( $msg, $query_param ) {
-
 		$WatchAnalyticsTitle = SpecialPage::getTitleFor( $this->getName() );
 
 		if ( $this->mMode == $query_param ) {
@@ -138,37 +131,36 @@ class SpecialWatchAnalytics extends SpecialPage {
 				wfMessage( $msg )->text()
 			);
 		} else {
-			$show = ( $query_param == '' ) ? array() : array( 'show' => $query_param );
+			$show = ( $query_param == '' ) ? [] : [ 'show' => $query_param ];
 			return Xml::element( 'a',
-				array( 'href' => $WatchAnalyticsTitle->getLocalURL( $show ) ),
+				[ 'href' => $WatchAnalyticsTitle->getLocalURL( $show ) ],
 				wfMessage( $msg )->text()
 			);
 		}
-
 	}
 
-	public function pagesList ( $filters ) {
+	public function pagesList( $filters ) {
 		return $this->createTablePager(
 			'watchanalytics-special-pages-pagetitle',
-			new WatchAnalyticsPageTablePager( $this, array(), $filters )
+			new WatchAnalyticsPageTablePager( $this, [], $filters )
 		);
 	}
 
-	public function usersList ( $filters ) {
+	public function usersList( $filters ) {
 		return $this->createTablePager(
 			'watchanalytics-special-users-pagetitle',
-			new WatchAnalyticsUserTablePager( $this, array(), $filters )
+			new WatchAnalyticsUserTablePager( $this, [], $filters )
 		);
 	}
 
-	public function wikiHistory () {
+	public function wikiHistory() {
 		return $this->createTablePager(
 			'watchanalytics-special-wikihistory-pagetitle',
-			new WatchAnalyticsWikiTablePager( $this, array() )
+			new WatchAnalyticsWikiTablePager( $this, [] )
 		);
 	}
 
-	public function createTablePager ( $titleMsg, WatchAnalyticsTablePager $tablePager ) {
+	public function createTablePager( $titleMsg, WatchAnalyticsTablePager $tablePager ) {
 		global $wgOut, $wgRequest;
 
 		$wgOut->setPageTitle( wfMessage( $titleMsg )->text() );
@@ -181,21 +173,19 @@ class SpecialWatchAnalytics extends SpecialPage {
 			$html .= $tablePager->getNavigationBar();
 			$html .= $body;
 			$html .= $tablePager->getNavigationBar();
-		}
-		else {
+		} else {
 			$html .= '<p>' . wfMsgHTML( 'listusers-noresult' ) . '</p>';
 		}
 		$wgOut->addHTML( $html );
 		return true;
 	}
 
-	public function forceGraph () {
-
+	public function forceGraph() {
 		global $wgOut;
 
 		$wgOut->setPageTitle( 'Watch Analytics: User/Page Watch Relationships' );
 
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 
 		// Load the module for the D3.js force directed graph
 		$wgOut->addModules( 'ext.watchanalytics.forcegraph.scripts' );
@@ -203,49 +193,48 @@ class SpecialWatchAnalytics extends SpecialPage {
 		$wgOut->addModuleStyles( 'ext.watchanalytics.forcegraph.styles' );
 
 		// SELECT
-		// 	watchlist.wl_title AS title,
-		// 	watchlist.wl_notificationtimestamp AS notification,
-		// 	user.user_name AS user_name,
-		// 	user.user_real_name AS real_name
+		// watchlist.wl_title AS title,
+		// watchlist.wl_notificationtimestamp AS notification,
+		// user.user_name AS user_name,
+		// user.user_real_name AS real_name
 		// FROM watchlist
 		// LEFT JOIN user ON user.user_id = watchlist.wl_user
 		// WHERE
-		// 	wl_namespace = 0
-		// 	AND user.user_name IN (\'Lwelsh\',\'Swray\',\'Balpert\',\'Ejmontal\',\'Cmavridi\', \'Sgeffert\', \'Smulhern\', \'Kgjohns1\', \'Bscheib\', \'Ssjohns5\')
+		// wl_namespace = 0
+		// AND user.user_name IN (\'Lwelsh\',\'Swray\',\'Balpert\',\'Ejmontal\',\'Cmavridi\', \'Sgeffert\', \'Smulhern\', \'Kgjohns1\', \'Bscheib\', \'Ssjohns5\')
 		// LIMIT 20000
 
 		$res = $dbr->select(
-			array(
+			[
 				'w' => 'watchlist',
 				'u' => 'user',
 				'p' => 'page',
-			),
-			array(
+			],
+			[
 				'w.wl_title AS title',
 				'w.wl_notificationtimestamp as notification',
 				'u.user_name as user_name',
 				'u.user_real_name AS real_name',
-			),
+			],
 			'w.wl_namespace = 0 AND p.page_is_redirect = 0',
 			__METHOD__,
-			array(
+			[
 				"LIMIT" => "100000",
-			),
-			array(
-				'u' => array(
+			],
+			[
+				'u' => [
 					'LEFT JOIN', 'u.user_id = w.wl_user'
-				),
-				'p' => array(
+				],
+				'p' => [
 					'RIGHT JOIN', 'w.wl_title = p.page_title AND w.wl_namespace = p.page_namespace'
-				),
-			)
+				],
+			]
 		);
 
-
-		$nodes = array();
-		$pages = array();
-		$users = array();
-		$links = array();
+		$nodes = [];
+		$pages = [];
+		$users = [];
+		$links = [];
 		while ( $row = $res->fetchRow() ) {
 
 			// if the page isn't in $pages, then it's also not in $nodes
@@ -256,11 +245,11 @@ class SpecialWatchAnalytics extends SpecialPage {
 				$pages[ $row['title'] ] = $nextNode;
 
 				// $nodes[ $nextNode ] = $row['title'];
-				$nodes[ $nextNode ] = array(
+				$nodes[ $nextNode ] = [
 					"name" => $row['title'],
 					"label" => $row['title'],
 					"group" => 1
-				);
+				];
 			}
 
 			// same for users...add to $users and $nodes accordingly
@@ -270,44 +259,41 @@ class SpecialWatchAnalytics extends SpecialPage {
 				$users[ $row['user_name'] ] = $nextNode;
 
 				$nodes[ $nextNode ] = $row['user_name'];
-				if ( $row['real_name'] !== NULL && trim( $row['real_name'] ) !== '' ) {
+				if ( $row['real_name'] !== null && trim( $row['real_name'] ) !== '' ) {
 					$displayName = $row['real_name'];
-				}
-				else {
+				} else {
 					$displayName = $row['user_name'];
 				}
 
-				$nodes[ $nextNode ] = array(
+				$nodes[ $nextNode ] = [
 					"name" => $displayName,
 					"label" => $displayName,
 					"group" => 2,
 					"weight" => 1
-				);
+				];
 
-			}
-			else {
+			} else {
 				$userNodeIndex = $users[ $row['user_name'] ];
 				$nodes[ $userNodeIndex ]['weight']++;
 			}
 
-			if ( $row['notification'] == NULL ) {
+			if ( $row['notification'] == null ) {
 				$linkClass = "link";
-			}
-			else {
+			} else {
 				$linkClass = "unreviewed";
 			}
 
 			// if ( $linkClass !== "unreviewed" ) {
-				$links[] = array(
+				$links[] = [
 					"source" => $users[ $row['user_name'] ],
 					"target" => $pages[ $row['title']     ],
 					"value"  => 1,
 					"linkclass" => $linkClass
-				);
+				];
 			// }
 		}
 
-		$json = array( "nodes" => $nodes, "links" => $links );
+		$json = [ "nodes" => $nodes, "links" => $links ];
 		$json = json_encode( $json ); // , JSON_PRETTY_PRINT );
 
 		$html = '<h3>' . wfMessage( 'watchanalytics-watch-forcegraph-header' )->text() . '</h3>';
@@ -316,7 +302,5 @@ class SpecialWatchAnalytics extends SpecialPage {
 		// $html .= "<pre>$json</pre>"; // easy testing
 		$html .= "<script type='text/template' id='mw-ext-watchAnalytics-forceGraph'>$json</script>";
 		$wgOut->addHTML( $html );
-
 	}
 }
-


### PR DESCRIPTION
Ran `phpcbf` to fix style issues, then manually cleaned up several things.

* If doc blocks are used, make sure `@param` and `@return` are properly set based on the function
* Function definition should be `public static` not `static public`
* Use short array syntax `[ ... ]` not `array( ... )`
* Various whitespace fixes
* Author and license blocks at the top of some files caused issues. I just removed them rather than dealing with it.
* Evidently it prefers `} else {` versus putting the `else` on a new line. I thought MW liked it on a new line.
* Change `DB_SLAVE` to `DB_REPLICA`
* For maintenance scripts, change `require_once( DO_MAINTENANCE )` to `require_once RUN_MAINTENANCE_IF_MAIN`
* `null` not `NULL`

None of these changes should effect performance, though a thorough test should be done since there are a LOT of changes.

Tests will still fail for this due to one content change that will come in a later PR.