### PR TITLE
Don't access $_POST directly

### DIFF
--- a/specials/SpecialClearPendingReviews.php
+++ b/specials/SpecialClearPendingReviews.php
@@ -156,7 +156,7 @@ class SpecialClearPendingReviews extends SpecialPage {
 		$output = $this->getOutput();
 		$this->setHeaders();
 
-		if ( isset( $_POST['clearpages'] ) ) {
+		if ( $request->wasPosted() && $request->getVal( 'clearpages' ) ) {
 			// Clears pending reviews
 			$results = $this->doSearchQuery( $data, true );
 


### PR DESCRIPTION
MediaWiki doesn't want direct access of `$_POST`. Use request class instead.