### PR TITLE
Fix bad type hint causing error on page-move

### DIFF
--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -265,7 +265,6 @@ class WatchStateRecorder {
 	 * Record relevant info in watch_tracking_page and watch_tracking_user
 	 * after a change to a page (e.g. an edit, a move, etc)
 	 *
-	 * @param $wikipage
 	 * @return bool
 	 */
 	public static function recordPageChange( $wikipage ) {

--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -265,7 +265,7 @@ class WatchStateRecorder {
 	 * Record relevant info in watch_tracking_page and watch_tracking_user
 	 * after a change to a page (e.g. an edit, a move, etc)
 	 *
-	 * @param WikiPage $wikipage
+	 * @param $wikipage
 	 * @return bool
 	 */
 	public static function recordPageChange( $wikipage ) {

--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -265,6 +265,7 @@ class WatchStateRecorder {
 	 * Record relevant info in watch_tracking_page and watch_tracking_user
 	 * after a change to a page (e.g. an edit, a move, etc)
 	 *
+	 * @param WikiPage $wikipage
 	 * @return bool
 	 */
 	public static function recordPageChange( $wikipage ) {

--- a/includes/WatchStateRecorder.php
+++ b/includes/WatchStateRecorder.php
@@ -268,7 +268,7 @@ class WatchStateRecorder {
 	 * @param WikiPage $wikipage
 	 * @return bool
 	 */
-	public static function recordPageChange( WikiPage $wikipage ) {
+	public static function recordPageChange( $wikipage ) {
 		$timestamp = date( "YmdHis", time() );
 		$title = $wikipage->getTitle();
 


### PR DESCRIPTION
Currently moving pages is broken. The page move works, but you get an error page. The error is:

```
/demo/index.php?title=Special:MovePage&action=submit TypeError from line 271 of /opt/htdocs/mediawiki/extensions/WatchAnalytics/includes/WatchStateRecorder.php: Argument 1 passed to WatchStateRecorder::recordPageChange() must be an instance of WikiPage, instance of Article given, called in /opt/htdocs/mediawiki/extensions/WatchAnalytics/Hooks.php on line 165
```

This is because type-hinting of `WikiPage` is used where `Article` is type. Removing the restriction should remove the error.