### PR TITLE
Add URL to unreview link so right-click-new-tab unreviews

### DIFF
--- a/includes/ReviewHandler.php
+++ b/includes/ReviewHandler.php
@@ -125,10 +125,16 @@ class ReviewHandler {
 			wfMessage( 'watchanalytics-accept-change-close-banner' )->text()
 		);
 
+		// used if user right-clicks link and opens in new tab
+		$unReviewURL = SpecialPage::getTitleFor( 'PageStatistics' )->getInternalURL( [
+			'page' => $this->title->getPrefixedText(),
+			'unreview' => $this->initial
+		] );
+
 		$unReviewLink = Xml::element(
 			'a',
 			[
-				'href' => null,
+				'href' => $unReviewURL,
 				'id' => 'watch-analytics-unreview',
 				'class' => 'watch-analytics-unreview',
 				'timestamp' => $this->initial,


### PR DESCRIPTION
#102 made it so "defer review" button was handled with javascript to defer the review and not leave the page. Previously the user was navigated to Special:PageStatistics which also handled un-reviewing. However, with the JS handling if a user does right-click then open-in-new-tab the JS handling is avoided and the user is navigated back to the same page _without_ un-reviewing. This change makes the old handling work again for users used to it.