### PR TITLE
Don't use deprecated ParserBeforeTidy hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -180,7 +180,7 @@
 		"MagicWordwgVariableIDs": [
 			"WatchAnalyticsHooks::addMagicWordVariableIDs"
 		],
-		"ParserBeforeTidy": [
+		"ParserAfterTidy": [
 			"WatchAnalyticsHooks::handleMagicWords"
 		],
 		"LanguageGetMagic": [


### PR DESCRIPTION
Access to "untidy" parser output is being removed and this hook is
being deprecated.

It is straightforward to switch to using the ParserAfterTidy hook instead.

ParserBeforeTidy deprecation in I4a0aae7b17fb522a5e4f90edad3a0b7137b270a6.