### PR TITLE
Use DB_MASTER when using query() to avoid error

### DIFF
--- a/includes/WatchAnalyticsParserFunctions.php
+++ b/includes/WatchAnalyticsParserFunctions.php
@@ -47,7 +47,7 @@ class WatchAnalyticsParserFunctions {
 		// $args = self::processArgs( $frame, $args, array(0) );
 		// $namespace  = $args[0];
 
-		$dbr = wfGetDB( DB_REPLICA );
+		$dbr = wfGetDB( DB_MASTER );
 
 		$query = "
 			SELECT * FROM (
@@ -121,7 +121,7 @@ class WatchAnalyticsParserFunctions {
 
 		$rangeTimestamp = date( 'YmdHis', time() - ( $numDays * 24 * 60 * 60 ) );
 
-		$dbr = wfGetDB( DB_REPLICA );
+		$dbr = wfGetDB( DB_MASTER );
 
 		if ( class_exists( 'Wiretap' ) && false ) {
 			$query =

--- a/specials/SpecialClearPendingReviews.php
+++ b/specials/SpecialClearPendingReviews.php
@@ -104,7 +104,7 @@ class SpecialClearPendingReviews extends SpecialPage {
 	 * @return $results
 	 */
 	public static function doSearchQuery( $data, $clearPages ) {
-		$dbw = wfGetDB( DB_REPLICA );
+		$dbw = wfGetDB( DB_MASTER );
 		$category = preg_replace( '/\s+/', '_', $data['category'] );
 		$page = preg_replace( '/\s+/', '_', $data['page'] );
 		$start = preg_replace( '/\s+/', '', $data['start'] );
@@ -133,7 +133,6 @@ class SpecialClearPendingReviews extends SpecialPage {
 		$results = $dbw->select( $tables, $vars, $conditions, __METHOD__, 'DISTINCT', $join_conds );
 
 		if ( $clearPages == true ) {
-			$dbw = wfGetDB( DB_MASTER );
 
 			foreach ( $results as $result ) {
 				$values = [ 'wl_notificationtimestamp' => null ];

--- a/specials/SpecialWatchAnalytics.php
+++ b/specials/SpecialWatchAnalytics.php
@@ -74,7 +74,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 		// FROM watchlist
 		// INNER JOIN page ON page.page_namespace = watchlist.wl_namespace AND page.page_title = watchlist.wl_title;		$dbr = wfGetDB( DB_SLAVE );
 
-		$dbr = wfGetDB( DB_REPLICA );
+		$db = wfGetDB( DB_MASTER );
 
 		// $res = $dbr->select(
 		// array(
@@ -96,7 +96,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 		// )
 		// );
 
-		$res = $dbr->query( '
+		$res = $db->query( '
 			SELECT
 				COUNT(*) AS num_watches,
 				SUM( IF(watchlist.wl_notificationtimestamp IS NULL, 0, 1) ) AS num_pending,
@@ -105,7 +105,7 @@ class SpecialWatchAnalytics extends SpecialPage {
 			INNER JOIN page ON page.page_namespace = watchlist.wl_namespace AND page.page_title = watchlist.wl_title;
 		' );
 
-		$allWikiData = $dbr->fetchRow( $res );
+		$allWikiData = $db->fetchRow( $res );
 
 		list( $watches, $pending, $percent ) = [
 			$allWikiData['num_watches'],


### PR DESCRIPTION
This appears to be a more recent change, that query() causes the
following error when used along with DB_REPLICA:

Wikimedia\Rdbms\DBReadOnlyRoleError from line 1195 of
$MW_INSTALL_PATH/includes/libs/rdbms/database/Database.php: Cannot
write; target role is DB_REPLICA

While WatchAnalytics was not using query() to write to the database, it
is possible to use query() that way, so it makes sense for MW to be more
strict with its usage.