### PR TITLE
3.2.0 release

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "WatchAnalytics",
-	"version": "3.1.1",
+	"version": "3.2.0",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:Jamesmontalvo3 James Montalvo]"
 	],


### PR DESCRIPTION
Changes:

- 15da667 Use DB_MASTER when using query() to avoid error
- 1601a7a Replace usage of long deprecated and removed wfSuppressWarnings and wfRestoreWarnings
- c3fcf01 Don't use deprecated ParserBeforeTidy hook
- 787611f Don't call WebRequest::getLimitOffset in 1.35

Contributors:

* James Montalvo
* C. Scott Ananian
* DannyS712
* Rich Evans

Thanks everyone!